### PR TITLE
Automate building and running of Tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,25 @@
+name: Tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup .NET SDK 6.0.x
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Install dependencies
+        run: dotnet restore src/StateSmith.sln
+
+      - name: Build
+        run: dotnet build --configuration Debug --no-restore src/StateSmith.sln
+
+      - name: Test
+        run: dotnet test --no-restore src/StateSmith.sln


### PR DESCRIPTION
# Overview

This PR addresses issue #32 and adds the building and running of the tests through Actions. 

Feel free to recommend adjustments to the naming conventions used.

It should be noted: 
- Tests currently fail due to existing test issues.
- Tests are built and executed on each push (this can be adjusted to specific branches if needed)
- Only .NET Core 6.0.x is supported for the tests.