### PR TITLE
Improve generated code by only nulling `ancestor_event_handler` when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Improved generated code clarity by showing step 1,2,3...
 - Improved generated code clarity by removing `if (true)` for behaviors with no guard clause.
+- Improved generated code by only nulling `ancestor_event_handler` when actually needed. https://github.com/StateSmith/StateSmith/issues/14
+
+---
 
 ## [0.6.0-alpha]
 ### Fixed

--- a/examples/BlankTemplate/BlankTemplate/BlankTemplateSm.c
+++ b/examples/BlankTemplate/BlankTemplate/BlankTemplateSm.c
@@ -59,7 +59,7 @@ void BlankTemplateSm_start(BlankTemplateSm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = BlankTemplateSm_StateId_STATE_1;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for ROOT.InitialState
     } // end of behavior for ROOT
@@ -140,7 +140,7 @@ static void STATE_1_do(BlankTemplateSm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = BlankTemplateSm_StateId_STATE_2;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for STATE_1
 }
@@ -181,7 +181,7 @@ static void STATE_2_do(BlankTemplateSm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = BlankTemplateSm_StateId_STATE_1;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for STATE_2
 }

--- a/examples/Blinky1/Blinky1/Blinky1Sm.cpp
+++ b/examples/Blinky1/Blinky1/Blinky1Sm.cpp
@@ -60,7 +60,7 @@ void Blinky1Sm_start(Blinky1Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Blinky1Sm_StateId_LED_OFF;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for ROOT.InitialState
     } // end of behavior for ROOT
@@ -156,7 +156,7 @@ static void LED_OFF_do(Blinky1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Blinky1Sm_StateId_LED_ON;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for LED_OFF
 }
@@ -206,7 +206,7 @@ static void LED_ON_do(Blinky1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Blinky1Sm_StateId_LED_OFF;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for LED_ON
 }

--- a/examples/Blinky1Printf/src/blinky1_printf_sm.c
+++ b/examples/Blinky1Printf/src/blinky1_printf_sm.c
@@ -57,7 +57,7 @@ void blinky1_printf_sm_start(blinky1_printf_sm* self) {
       
       // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
       self->state_id = BLINKY1_PRINTF_SM_STATE_ID_LED_OFF;
-      self->ancestor_event_handler = NULL;
+      // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
       return;
     } // end of behavior for ROOT.InitialState
   } // end of behavior for ROOT
@@ -143,7 +143,7 @@ static void LED_OFF_do(blinky1_printf_sm* self) {
     
     // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
     self->state_id = BLINKY1_PRINTF_SM_STATE_ID_LED_ON;
-    self->ancestor_event_handler = NULL;
+    // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
     return;
   } // end of behavior for LED_OFF
 }
@@ -188,7 +188,7 @@ static void LED_ON_do(blinky1_printf_sm* self) {
     
     // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
     self->state_id = BLINKY1_PRINTF_SM_STATE_ID_LED_OFF;
-    self->ancestor_event_handler = NULL;
+    // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
     return;
   } // end of behavior for LED_ON
 }

--- a/examples/ButtonSm1Cpp/ButtonSm1Cpp/ButtonSm1Cpp.cpp
+++ b/examples/ButtonSm1Cpp/ButtonSm1Cpp/ButtonSm1Cpp.cpp
@@ -66,7 +66,7 @@ void ButtonSm1Cpp_start(ButtonSm1Cpp* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = ButtonSm1Cpp_StateId_NOT_PRESSED;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for ROOT.InitialState
     } // end of behavior for ROOT
@@ -168,7 +168,7 @@ static void NOT_PRESSED_do(ButtonSm1Cpp* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = ButtonSm1Cpp_StateId_CONFIRMING_HELD;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for PRESSED.InitialState
     } // end of behavior for NOT_PRESSED
@@ -223,7 +223,7 @@ static void PRESSED_do(ButtonSm1Cpp* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = ButtonSm1Cpp_StateId_NOT_PRESSED;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for PRESSED
 }

--- a/examples/LaserTagMenu1/LaserTagMenu1/ButtonSm1.c
+++ b/examples/LaserTagMenu1/LaserTagMenu1/ButtonSm1.c
@@ -66,7 +66,7 @@ void ButtonSm1_start(ButtonSm1* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = ButtonSm1_StateId_NOT_PRESSED;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for ROOT.InitialState
     } // end of behavior for ROOT
@@ -167,7 +167,7 @@ static void NOT_PRESSED_do(ButtonSm1* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = ButtonSm1_StateId_CONFIRMING_HELD;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for PRESSED.InitialState
     } // end of behavior for NOT_PRESSED
@@ -222,7 +222,7 @@ static void PRESSED_do(ButtonSm1* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = ButtonSm1_StateId_NOT_PRESSED;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for PRESSED
 }

--- a/examples/LaserTagMenu1/LaserTagMenu1/LaserTagMenu1Sm.c
+++ b/examples/LaserTagMenu1/LaserTagMenu1/LaserTagMenu1Sm.c
@@ -181,7 +181,7 @@ void LaserTagMenu1Sm_start(LaserTagMenu1Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = LaserTagMenu1Sm_StateId_WELCOME_SCREEN;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for ROOT.InitialState
     } // end of behavior for ROOT
@@ -299,7 +299,7 @@ static void HOME_ok_press(LaserTagMenu1Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = LaserTagMenu1Sm_StateId_MM_SELECT_CLASS_OPTION;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for MAIN_MENU.InitialState
     } // end of behavior for HOME
@@ -350,7 +350,7 @@ static void HOME1_down_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_HOME2;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for HOME1
 }
@@ -372,7 +372,7 @@ static void HOME1_up_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_HOME3;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for HOME1
 }
@@ -422,7 +422,7 @@ static void HOME2_down_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_HOME3;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for HOME2
 }
@@ -444,7 +444,7 @@ static void HOME2_up_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_HOME1;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for HOME2
 }
@@ -494,7 +494,7 @@ static void HOME3_down_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_HOME1;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for HOME3
 }
@@ -516,7 +516,7 @@ static void HOME3_up_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_HOME2;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for HOME3
 }
@@ -569,7 +569,7 @@ static void MENUS_GROUP_back_held(LaserTagMenu1Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = LaserTagMenu1Sm_StateId_HOME1;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for HOME.InitialState
     } // end of behavior for MENUS_GROUP
@@ -602,7 +602,7 @@ static void MENUS_GROUP_back_press(LaserTagMenu1Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = LaserTagMenu1Sm_StateId_HOME1;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for HOME.InitialState
     } // end of behavior for MENUS_GROUP
@@ -660,7 +660,7 @@ static void CLASS_SAVED_do(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SELECT_CLASS_OPTION;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for CLASS_SAVED
 }
@@ -751,7 +751,7 @@ static void MM_BACK_PRESS_EATER_OPTION_ok_press(LaserTagMenu1Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = LaserTagMenu1Sm_StateId_MM_BACK_PRESS_EATER_1;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for MM_BACK_PRESS_EATER.InitialState
     } // end of behavior for MM_BACK_PRESS_EATER_OPTION
@@ -774,7 +774,7 @@ static void MM_BACK_PRESS_EATER_OPTION_up_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SHOW_INFO_OPTION;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_BACK_PRESS_EATER_OPTION
 }
@@ -825,7 +825,7 @@ static void MM_SELECT_CLASS_OPTION_down_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SHOW_INFO_OPTION;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SELECT_CLASS_OPTION
 }
@@ -857,7 +857,7 @@ static void MM_SELECT_CLASS_OPTION_ok_press(LaserTagMenu1Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = LaserTagMenu1Sm_StateId_MM_SC_ENGINEER;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for MM_SELECT_CLASS.InitialState
     } // end of behavior for MM_SELECT_CLASS_OPTION
@@ -917,7 +917,7 @@ static void MM_SHOW_INFO_OPTION_down_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_BACK_PRESS_EATER_OPTION;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SHOW_INFO_OPTION
 }
@@ -949,7 +949,7 @@ static void MM_SHOW_INFO_OPTION_ok_press(LaserTagMenu1Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = LaserTagMenu1Sm_StateId_MM_SHOW_INFO_1;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for MM_SHOW_INFO.InitialState
     } // end of behavior for MM_SHOW_INFO_OPTION
@@ -972,7 +972,7 @@ static void MM_SHOW_INFO_OPTION_up_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SELECT_CLASS_OPTION;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SHOW_INFO_OPTION
 }
@@ -1070,7 +1070,7 @@ static void MM_BACK_PRESS_EATER_1_do(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_BACK_PRESS_EATER_2;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_BACK_PRESS_EATER_1
 }
@@ -1126,7 +1126,7 @@ static void MM_BACK_PRESS_EATER_2_do(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_BACK_PRESS_EATER_3;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_BACK_PRESS_EATER_2
 }
@@ -1182,7 +1182,7 @@ static void MM_BACK_PRESS_EATER_3_do(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_BACK_PRESS_EATER_4;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_BACK_PRESS_EATER_3
 }
@@ -1238,7 +1238,7 @@ static void MM_BACK_PRESS_EATER_4_do(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_BACK_PRESS_EATER_5;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_BACK_PRESS_EATER_4
 }
@@ -1320,7 +1320,7 @@ static void MM_BACK_PRESS_EATER_5_do(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_BACK_PRESS_EATER_2;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_BACK_PRESS_EATER_5
     
@@ -1338,7 +1338,7 @@ static void MM_BACK_PRESS_EATER_5_do(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_BACK_PRESS_EATER_5;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_BACK_PRESS_EATER_5
 }
@@ -1424,7 +1424,7 @@ static void MM_SELECT_CLASS_ok_press(LaserTagMenu1Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = LaserTagMenu1Sm_StateId_CLASS_SAVED;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for MM_SELECT_CLASS.ExitPoint(saved)
     } // end of behavior for MM_SELECT_CLASS
@@ -1476,7 +1476,7 @@ static void MM_SC_ENGINEER_down_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SC_HEAVY;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SC_ENGINEER
 }
@@ -1526,7 +1526,7 @@ static void MM_SC_MID_down_held(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SC_SPY;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SC_MID
 }
@@ -1548,7 +1548,7 @@ static void MM_SC_MID_up_held(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SC_ENGINEER;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SC_MID
 }
@@ -1598,7 +1598,7 @@ static void MM_SC_ARCHER_down_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SC_WIZARD;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SC_ARCHER
 }
@@ -1620,7 +1620,7 @@ static void MM_SC_ARCHER_up_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SC_HEAVY;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SC_ARCHER
 }
@@ -1671,7 +1671,7 @@ static void MM_SC_HEAVY_down_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SC_ARCHER;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SC_HEAVY
 }
@@ -1693,7 +1693,7 @@ static void MM_SC_HEAVY_up_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SC_ENGINEER;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SC_HEAVY
 }
@@ -1743,7 +1743,7 @@ static void MM_SC_WIZARD_down_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SC_SPY;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SC_WIZARD
 }
@@ -1765,7 +1765,7 @@ static void MM_SC_WIZARD_up_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SC_ARCHER;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SC_WIZARD
 }
@@ -1815,7 +1815,7 @@ static void MM_SC_SPY_up_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SC_WIZARD;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SC_SPY
 }
@@ -1911,7 +1911,7 @@ static void MM_SHOW_INFO_1_do(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SHOW_INFO_2;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SHOW_INFO_1
 }
@@ -1933,7 +1933,7 @@ static void MM_SHOW_INFO_1_down_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SHOW_INFO_2;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SHOW_INFO_1
 }
@@ -1986,7 +1986,7 @@ static void MM_SHOW_INFO_2_do(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SHOW_INFO_3;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SHOW_INFO_2
 }
@@ -2008,7 +2008,7 @@ static void MM_SHOW_INFO_2_down_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SHOW_INFO_3;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SHOW_INFO_2
 }
@@ -2061,7 +2061,7 @@ static void MM_SHOW_INFO_3_do(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SHOW_INFO_1;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SHOW_INFO_3
 }
@@ -2083,7 +2083,7 @@ static void MM_SHOW_INFO_3_down_press(LaserTagMenu1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = LaserTagMenu1Sm_StateId_MM_SHOW_INFO_1;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for MM_SHOW_INFO_3
 }
@@ -2149,7 +2149,7 @@ static void WELCOME_SCREEN_do(LaserTagMenu1Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = LaserTagMenu1Sm_StateId_HOME1;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for HOME.InitialState
     } // end of behavior for WELCOME_SCREEN

--- a/examples/Tutorial1-blank/src/Tutorial1Sm.c
+++ b/examples/Tutorial1-blank/src/Tutorial1Sm.c
@@ -61,7 +61,7 @@ void Tutorial1Sm_start(Tutorial1Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Tutorial1Sm_StateId_OFF;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for ROOT.InitialState
     } // end of behavior for ROOT
@@ -149,7 +149,7 @@ static void OFF_increase(Tutorial1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Tutorial1Sm_StateId_ON1;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for OFF
 }
@@ -199,7 +199,7 @@ static void ON1_dim(Tutorial1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Tutorial1Sm_StateId_OFF;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for ON1
 }
@@ -221,7 +221,7 @@ static void ON1_off(Tutorial1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Tutorial1Sm_StateId_OFF;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for ON1
 }

--- a/examples/Tutorial1-complete/src/Tutorial1Sm.c
+++ b/examples/Tutorial1-complete/src/Tutorial1Sm.c
@@ -78,7 +78,7 @@ void Tutorial1Sm_start(Tutorial1Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Tutorial1Sm_StateId_OFF;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for ROOT.InitialState
     } // end of behavior for ROOT
@@ -195,7 +195,7 @@ static void OFF_increase(Tutorial1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Tutorial1Sm_StateId_ON1;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for OFF
 }
@@ -236,7 +236,7 @@ static void ON_GROUP_off(Tutorial1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Tutorial1Sm_StateId_OFF;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for ON_GROUP
 }
@@ -286,7 +286,7 @@ static void ON1_dim(Tutorial1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Tutorial1Sm_StateId_OFF;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for ON1
 }
@@ -308,7 +308,7 @@ static void ON1_increase(Tutorial1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Tutorial1Sm_StateId_ON2;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for ON1
 }
@@ -358,7 +358,7 @@ static void ON2_dim(Tutorial1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Tutorial1Sm_StateId_ON1;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for ON2
 }
@@ -380,7 +380,7 @@ static void ON2_increase(Tutorial1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Tutorial1Sm_StateId_ON3;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for ON2
 }
@@ -431,7 +431,7 @@ static void ON3_dim(Tutorial1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Tutorial1Sm_StateId_ON2;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for ON3
 }
@@ -467,7 +467,7 @@ static void ON3_increase(Tutorial1Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Tutorial1Sm_StateId_BOOM;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for ON3
 }

--- a/src/StateSmith/output/C99BalancedCoder1/CBuilder.cs
+++ b/src/StateSmith/output/C99BalancedCoder1/CBuilder.cs
@@ -132,7 +132,7 @@ namespace StateSmith.output.C99BalancedCoder1
 
             var getToInitialStateBehavior = new Behavior(sm, initialState);
 
-            eventHandlerBuilder.OutputTransitionCode(getToInitialStateBehavior);
+            eventHandlerBuilder.OutputTransitionCode(getToInitialStateBehavior, noAncestorHandlesEvent: true);
 
             file.FinishCodeBlock(forceNewLine: true);
             file.AppendLine();

--- a/src/StateSmithTest/spec/1/c/Spec1Sm.c
+++ b/src/StateSmithTest/spec/1/c/Spec1Sm.c
@@ -94,7 +94,7 @@ void Spec1Sm_start(Spec1Sm* self)
                     
                     // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
                     self->state_id = Spec1Sm_StateId_S11;
-                    self->ancestor_event_handler = NULL;
+                    // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
                     return;
                 } // end of behavior for S1.InitialState
             } // end of behavior for S.InitialState
@@ -298,7 +298,7 @@ static void S11_ev1(Spec1Sm* self)
                 
                 // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
                 self->state_id = Spec1Sm_StateId_T111;
-                self->ancestor_event_handler = NULL;
+                // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
                 return;
             } // end of behavior for T11.EntryPoint(1)
         } // end of behavior for S1.ExitPoint(1)
@@ -399,7 +399,7 @@ static void T11_ev2(Spec1Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec1Sm_StateId_S11;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for S1.InitialState
     } // end of behavior for T11

--- a/src/StateSmithTest/spec/1b/c/Spec1bSm.c
+++ b/src/StateSmithTest/spec/1b/c/Spec1bSm.c
@@ -88,7 +88,7 @@ void Spec1bSm_start(Spec1bSm* self)
                     
                     // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
                     self->state_id = Spec1bSm_StateId_S1_1;
-                    self->ancestor_event_handler = NULL;
+                    // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
                     return;
                 } // end of behavior for S1.InitialState
             } // end of behavior for S.InitialState
@@ -211,7 +211,7 @@ static void S1_t1(Spec1bSm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec1bSm_StateId_S2_1;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for S2.InitialState
     } // end of behavior for S1

--- a/src/StateSmithTest/spec/2/Spec2Sm.graphml
+++ b/src/StateSmithTest/spec/2/Spec2Sm.graphml
@@ -945,7 +945,6 @@ enter / clear_output();</y:NodeLabel>
             </node>
             <node id="n0::n5::n3" yfiles.foldertype="group">
               <data key="d4" xml:space="preserve"/>
-              <data key="d5"/>
               <data key="d6">
                 <y:ProxyAutoBoundsNode>
                   <y:Realizers active="0">
@@ -1445,7 +1444,6 @@ it clear that these are all local transitions.
               </data>
             </edge>
             <edge id="n0::n5::e6" source="n0::n5::n2" target="n0::n5::n3::n0">
-              <data key="d9"/>
               <data key="d10">
                 <y:QuadCurveEdge straightness="0.1">
                   <y:Path sx="18.734012237082652" sy="23.100000000000023" tx="55.949056013600284" ty="-191.64717708526473"/>
@@ -1456,7 +1454,6 @@ it clear that these are all local transitions.
               </data>
             </edge>
             <edge id="n0::n5::e7" source="n0::n5::n2" target="n0::n5::n3::n2">
-              <data key="d9"/>
               <data key="d10">
                 <y:QuadCurveEdge straightness="0.1">
                   <y:Path sx="251.35494841724721" sy="23.100000000000023" tx="-21.722939910082232" ty="-193.4186198664654"/>
@@ -1467,7 +1464,6 @@ it clear that these are all local transitions.
               </data>
             </edge>
             <edge id="n0::n5::e8" source="n0::n5::n2" target="n0::n5::n3::n1">
-              <data key="d9"/>
               <data key="d10">
                 <y:QuadCurveEdge straightness="0.1">
                   <y:Path sx="541.9112760642761" sy="23.100000000000023" tx="-51.510498372079155" ty="-183.96069259204944"/>
@@ -2272,7 +2268,7 @@ EV5 / count++;</y:NodeLabel>
               <data key="d5" xml:space="preserve"><![CDATA[pseudo_initial]]></data>
               <data key="d6">
                 <y:ShapeNode>
-                  <y:Geometry height="19.0" width="20.0" x="257.5514213460493" y="776.1623326608546"/>
+                  <y:Geometry height="19.0" width="20.0" x="257.5514213460493" y="758.8149339085525"/>
                   <y:Fill color="#000000" transparent="false"/>
                   <y:BorderStyle color="#000000" raised="false" type="line" width="1.0"/>
                   <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="18.701171875" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="bottom" visible="false" width="70.708984375" x="-25.3544921875" xml:space="preserve" y="0.1494140625">$initial_state<y:LabelModel><y:SmartNodeLabelModel distance="4.0"/></y:LabelModel><y:ModelParameter><y:SmartNodeLabelModelParameter labelRatioX="0.0" labelRatioY="0.0" nodeRatioX="0.0" nodeRatioY="0.0" offsetX="0.0" offsetY="0.0" upX="0.0" upY="-1.0"/></y:ModelParameter></y:NodeLabel>
@@ -2283,11 +2279,12 @@ EV5 / count++;</y:NodeLabel>
             <node id="n0::n9::n1">
               <data key="d6">
                 <y:ShapeNode>
-                  <y:Geometry height="46.200000000000045" width="394.55010435880115" x="185.3712025833989" y="674.3275045358548"/>
+                  <y:Geometry height="46.200000000000045" width="394.55010435880115" x="366.1712025833989" y="748.9623326608546"/>
                   <y:Fill color="#CCFFFF" transparent="false"/>
                   <y:BorderStyle color="#000000" raised="false" type="line" width="1.0"/>
-                  <y:NodeLabel alignment="left" autoSizePolicy="node_size" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="46.200000000000045" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="bottom" visible="true" width="394.55010435880115" x="-2.8421709430404007E-14" xml:space="preserve" y="0.0">$NOTES
-<y:LabelModel><y:SmartNodeLabelModel distance="4.0"/></y:LabelModel><y:ModelParameter><y:SmartNodeLabelModelParameter labelRatioX="0.0" labelRatioY="0.0" nodeRatioX="0.0" nodeRatioY="0.0" offsetX="0.0" offsetY="0.0" upX="0.0" upY="-1.0"/></y:ModelParameter></y:NodeLabel>
+                  <y:NodeLabel alignment="left" autoSizePolicy="node_size" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="48.103515625" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="bottom" visible="true" width="394.55010435880115" x="5.6843418860808015E-14" xml:space="preserve" y="-0.9517578124999773">$NOTES
+EV3 in TEST8_ROOT for testing case where pseudo state function
+finishes transition and ancestor does also handle the event.<y:LabelModel><y:SmartNodeLabelModel distance="4.0"/></y:LabelModel><y:ModelParameter><y:SmartNodeLabelModelParameter labelRatioX="0.0" labelRatioY="0.0" nodeRatioX="0.0" nodeRatioY="0.0" offsetX="0.0" offsetY="0.0" upX="0.0" upY="-1.0"/></y:ModelParameter></y:NodeLabel>
                   <y:Shape type="roundrectangle"/>
                 </y:ShapeNode>
               </data>
@@ -2298,12 +2295,13 @@ EV5 / count++;</y:NodeLabel>
                 <y:ProxyAutoBoundsNode>
                   <y:Realizers active="0">
                     <y:GroupNode>
-                      <y:Geometry height="481.1724564016454" width="480.0654660512629" x="167.3612834559182" y="834.4788281250001"/>
+                      <y:Geometry height="499.5489212453954" width="480.0654660512629" x="167.3612834559182" y="816.1023632812501"/>
                       <y:Fill color="#F5F5F5" transparent="false"/>
                       <y:BorderStyle color="#000000" type="dashed" width="1.0"/>
-                      <y:NodeLabel alignment="left" autoSizePolicy="node_width" backgroundColor="#EBEBEB" borderDistance="0.0" fontFamily="Dialog" fontSize="15" fontStyle="plain" hasLineColor="false" height="59.12939453125" horizontalTextPosition="center" iconTextGap="4" modelName="internal" modelPosition="t" textColor="#000000" verticalTextPosition="bottom" visible="true" width="480.0654660512629" x="0.0" xml:space="preserve" y="0.0">    TEST8_ROOT
+                      <y:NodeLabel alignment="left" autoSizePolicy="node_width" backgroundColor="#EBEBEB" borderDistance="0.0" fontFamily="Dialog" fontSize="15" fontStyle="plain" hasLineColor="false" height="77.505859375" horizontalTextPosition="center" iconTextGap="4" modelName="internal" modelPosition="t" textColor="#000000" verticalTextPosition="bottom" visible="true" width="480.0654660512629" x="0.0" xml:space="preserve" y="0.0">    TEST8_ROOT
 enter / clear_output();
-EV5 / count++;</y:NodeLabel>
+EV5 / count++;
+EV3 / </y:NodeLabel>
                       <y:Shape type="roundrectangle"/>
                       <y:State closed="false" closedHeight="50.0" closedWidth="50.0" innerGraphDisplayEnabled="false"/>
                       <y:Insets bottom="15" bottomF="15.0" left="15" leftF="15.0" right="15" rightF="15.0" top="15" topF="15.0"/>
@@ -2313,9 +2311,10 @@ EV5 / count++;</y:NodeLabel>
                       <y:Geometry height="50.0" width="50.0" x="0.0" y="60.0"/>
                       <y:Fill color="#F5F5F5" transparent="false"/>
                       <y:BorderStyle color="#000000" type="dashed" width="1.0"/>
-                      <y:NodeLabel alignment="right" autoSizePolicy="node_width" backgroundColor="#EBEBEB" borderDistance="0.0" fontFamily="Dialog" fontSize="15" fontStyle="plain" hasLineColor="false" height="59.12939453125" horizontalTextPosition="center" iconTextGap="4" modelName="internal" modelPosition="t" textColor="#000000" verticalTextPosition="bottom" visible="true" width="147.408203125" x="-48.7041015625" xml:space="preserve" y="0.0">    TEST8_ROOT
+                      <y:NodeLabel alignment="right" autoSizePolicy="node_width" backgroundColor="#EBEBEB" borderDistance="0.0" fontFamily="Dialog" fontSize="15" fontStyle="plain" hasLineColor="false" height="77.505859375" horizontalTextPosition="center" iconTextGap="4" modelName="internal" modelPosition="t" textColor="#000000" verticalTextPosition="bottom" visible="true" width="147.408203125" x="-48.7041015625" xml:space="preserve" y="0.0">    TEST8_ROOT
 enter / clear_output();
-EV5 / count++;</y:NodeLabel>
+EV5 / count++;
+EV3 / </y:NodeLabel>
                       <y:Shape type="roundrectangle"/>
                       <y:State closed="true" closedHeight="50.0" closedWidth="50.0" innerGraphDisplayEnabled="false"/>
                       <y:Insets bottom="5" bottomF="5.0" left="5" leftF="5.0" right="5" rightF="5.0" top="5" topF="5.0"/>
@@ -2465,7 +2464,7 @@ EV5 / count++;</y:NodeLabel>
                   <y:Path sx="0.0" sy="9.5" tx="-141.34755469924062" ty="-240.5888063258219"/>
                   <y:LineStyle color="#000000" type="line" width="1.0"/>
                   <y:Arrows source="none" target="standard"/>
-                  <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="18.701171875" horizontalTextPosition="center" iconTextGap="4" modelName="free" modelPosition="anywhere" preferredPlacement="anywhere" ratio="0.5" textColor="#000000" verticalTextPosition="bottom" visible="true" width="59.359375" x="4.425670575310676" xml:space="preserve" y="6.31606291347623">via entry 1<y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" frozen="true" placement="anywhere" side="anywhere" sideReference="relative_to_edge_flow"/></y:EdgeLabel>
+                  <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="18.701171875" horizontalTextPosition="center" iconTextGap="4" modelName="free" modelPosition="anywhere" preferredPlacement="anywhere" ratio="0.5" textColor="#000000" verticalTextPosition="bottom" visible="true" width="59.359375" x="4.527882124439998" xml:space="preserve" y="6.091626915036045">via entry 1<y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" frozen="true" placement="anywhere" side="anywhere" sideReference="relative_to_edge_flow"/></y:EdgeLabel>
                 </y:QuadCurveEdge>
               </data>
             </edge>

--- a/src/StateSmithTest/spec/2/c/Spec2CTests.cs
+++ b/src/StateSmithTest/spec/2/c/Spec2CTests.cs
@@ -177,6 +177,8 @@ public class Spec2CTests : Spec2CFixture
             Transition action `` for TEST2_S2 to TEST2_S2.
             Enter TEST2_S2.
         ");
+
+        //output.Should().Be(""); // uncomment below line if you want to see the whole output
         Assert.Equal(expected, output);
     }
 
@@ -300,9 +302,7 @@ public class Spec2CTests : Spec2CFixture
 
         ex = ex.Trim();
 
-        // uncomment below line if you want to see the whole output
-        //output.Should().Be("");
-
+        //output.Should().Be(""); // uncomment below line if you want to see the whole output
         Assert.Equal(ex, output);
     }
 

--- a/src/StateSmithTest/spec/2/c/Spec2Sm.c
+++ b/src/StateSmithTest/spec/2/c/Spec2Sm.c
@@ -257,6 +257,7 @@ static void TEST8_ENTRY_CHOICE_exit(Spec2Sm* self);
 
 static void TEST8_ROOT_enter(Spec2Sm* self);
 static void TEST8_ROOT_exit(Spec2Sm* self);
+static void TEST8_ROOT_ev3(Spec2Sm* self);
 static void TEST8_ROOT_ev5(Spec2Sm* self);
 
 static void TEST8_G_enter(Spec2Sm* self);
@@ -380,7 +381,7 @@ void Spec2Sm_start(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_DECIDE;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for ROOT.InitialState
     } // end of behavior for ROOT
@@ -612,7 +613,7 @@ static void DECIDE_ev1(Spec2Sm* self)
                 
                 // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
                 self->state_id = Spec2Sm_StateId_TEST1_S1_1;
-                self->ancestor_event_handler = NULL;
+                // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
                 return;
             } // end of behavior for TEST1_ROOT.InitialState
         } // end of behavior for TEST1_DO_EVENT_TESTING.InitialState
@@ -650,7 +651,7 @@ static void DECIDE_ev10(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST10_S1;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST10_CHOICE_POINT.InitialState
     } // end of behavior for DECIDE
@@ -698,7 +699,7 @@ static void DECIDE_ev2(Spec2Sm* self)
                 
                 // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
                 self->state_id = Spec2Sm_StateId_TEST2_S1_1;
-                self->ancestor_event_handler = NULL;
+                // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
                 return;
             } // end of behavior for TEST2_ROOT.InitialState
         } // end of behavior for TEST2_REGULAR_EVENT_TESTING.InitialState
@@ -746,7 +747,7 @@ static void DECIDE_ev3(Spec2Sm* self)
                 
                 // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
                 self->state_id = Spec2Sm_StateId_TEST3_S1;
-                self->ancestor_event_handler = NULL;
+                // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
                 return;
             } // end of behavior for TEST3_ROOT.InitialState
         } // end of behavior for TEST3_BEHAVIOR_ORDERING.InitialState
@@ -783,7 +784,7 @@ static void DECIDE_ev4(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST4_DECIDE;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST4_PARENT_CHILD_TRANSITIONS.InitialState
     } // end of behavior for DECIDE
@@ -819,7 +820,7 @@ static void DECIDE_ev5(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST5_ROOT;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST5_PARENT_CHILD_TRANSITIONS_ALIAS.InitialState
     } // end of behavior for DECIDE
@@ -866,7 +867,7 @@ static void DECIDE_ev6(Spec2Sm* self)
                 
                 // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
                 self->state_id = Spec2Sm_StateId_TEST6_S1;
-                self->ancestor_event_handler = NULL;
+                // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
                 return;
             } // end of behavior for TEST6_ROOT.InitialState
         } // end of behavior for TEST6_VARIABLES.InitialState
@@ -914,7 +915,7 @@ static void DECIDE_ev7(Spec2Sm* self)
                 
                 // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
                 self->state_id = Spec2Sm_StateId_TEST7_S1;
-                self->ancestor_event_handler = NULL;
+                // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
                 return;
             } // end of behavior for TEST7_ROOT.InitialState
         } // end of behavior for TEST7_INITIAL_CHOICE.InitialState
@@ -987,7 +988,7 @@ static void DECIDE_ev9(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST9_DECIDE;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST9_EXIT_CHOICE.InitialState
     } // end of behavior for DECIDE
@@ -1179,7 +1180,7 @@ static void TEST1_S1_1_ev1(Spec2Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Spec2Sm_StateId_TEST1_S2;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for TEST1_S1_1
 }
@@ -2145,7 +2146,7 @@ static void TEST2_ROOT_ev1(Spec2Sm* self)
     {
         // Step 1: execute action ``
         // Step 2: determine if ancestor gets to handle event next.
-        self->ancestor_event_handler = NULL;  // consume event
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
     } // end of behavior for TEST2_ROOT
 }
 
@@ -2159,7 +2160,7 @@ static void TEST2_ROOT_ev2(Spec2Sm* self)
     {
         // Step 1: execute action ``
         // Step 2: determine if ancestor gets to handle event next.
-        self->ancestor_event_handler = NULL;  // consume event
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
     } // end of behavior for TEST2_ROOT
 }
 
@@ -2433,7 +2434,7 @@ static void TEST3_ROOT_ev1(Spec2Sm* self)
     {
         // Step 1: execute action ``
         // Step 2: determine if ancestor gets to handle event next.
-        self->ancestor_event_handler = NULL;  // consume event
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
     } // end of behavior for TEST3_ROOT
 }
 
@@ -2794,7 +2795,7 @@ static void TEST4B_G_ev1(Spec2Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Spec2Sm_StateId_TEST4B_G_1;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for TEST4B_G
 }
@@ -2850,7 +2851,7 @@ static void TEST4B_G_1_ev2(Spec2Sm* self)
         // Already in target. No entering required.
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Spec2Sm_StateId_TEST4B_G;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for TEST4B_G_1
 }
@@ -2938,7 +2939,7 @@ static void TEST4C_G_ev1(Spec2Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Spec2Sm_StateId_TEST4C_G_1;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for TEST4C_G
 }
@@ -2994,7 +2995,7 @@ static void TEST4C_G_1_ev2(Spec2Sm* self)
         // Already in target. No entering required.
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Spec2Sm_StateId_TEST4C_G;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for TEST4C_G_1
 }
@@ -3095,7 +3096,7 @@ static void TEST4D_G_ev1(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST4D_G_1;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST4D_EXTERNAL.ChoicePoint()
     } // end of behavior for TEST4D_G
@@ -3165,7 +3166,7 @@ static void TEST4D_G_1_ev2(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST4D_G;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST4D_EXTERNAL.ChoicePoint()
     } // end of behavior for TEST4D_G_1
@@ -3229,7 +3230,7 @@ static void TEST4_DECIDE_ev1(Spec2Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Spec2Sm_StateId_TEST4_ROOT;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for TEST4_DECIDE
 }
@@ -3265,7 +3266,7 @@ static void TEST4_DECIDE_ev2(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST4B_G;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST4B_LOCAL.InitialState
     } // end of behavior for TEST4_DECIDE
@@ -3302,7 +3303,7 @@ static void TEST4_DECIDE_ev3(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST4C_G;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST4C_LOCAL_TO_ALIAS.InitialState
     } // end of behavior for TEST4_DECIDE
@@ -3339,7 +3340,7 @@ static void TEST4_DECIDE_ev4(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST4D_G;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST4D_EXTERNAL.InitialState
     } // end of behavior for TEST4_DECIDE
@@ -3409,7 +3410,7 @@ static void TEST4_ROOT_ev2(Spec2Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Spec2Sm_StateId_TEST4_S1;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for TEST4_ROOT
 }
@@ -3434,7 +3435,7 @@ static void TEST4_ROOT_ev3(Spec2Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Spec2Sm_StateId_TEST4_S10_1;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for TEST4_ROOT
 }
@@ -3469,7 +3470,7 @@ static void TEST4_ROOT_ev4(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST4_S20_1;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST4_S20.InitialState
     } // end of behavior for TEST4_ROOT
@@ -3527,7 +3528,7 @@ static void TEST4_S1_ev1(Spec2Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Spec2Sm_StateId_TEST4_S2;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for TEST4_S1
 }
@@ -3673,7 +3674,7 @@ static void TEST4_S2_ev1(Spec2Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Spec2Sm_StateId_TEST4_S3;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for TEST4_S2
 }
@@ -3830,7 +3831,7 @@ static void TEST4_S3_ev1(Spec2Sm* self)
         // Already in target. No entering required.
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Spec2Sm_StateId_TEST4_ROOT;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for TEST4_S3
 }
@@ -3926,7 +3927,7 @@ static void TEST5_ROOT_ev2(Spec2Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Spec2Sm_StateId_TEST5_S1;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for TEST5_ROOT
 }
@@ -3983,7 +3984,7 @@ static void TEST5_S1_ev1(Spec2Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Spec2Sm_StateId_TEST5_S2;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for TEST5_S1
 }
@@ -4040,7 +4041,7 @@ static void TEST5_S2_ev1(Spec2Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Spec2Sm_StateId_TEST5_S3;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for TEST5_S2
 }
@@ -4096,7 +4097,7 @@ static void TEST5_S3_ev1(Spec2Sm* self)
         // Already in target. No entering required.
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Spec2Sm_StateId_TEST5_ROOT;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for TEST5_S3
 }
@@ -4237,7 +4238,7 @@ static void TEST6_S1_ev1(Spec2Sm* self)
         
         // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
         self->state_id = Spec2Sm_StateId_TEST6_S2;
-        self->ancestor_event_handler = NULL;
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
         return;
     } // end of behavior for TEST6_S1
 }
@@ -4427,7 +4428,7 @@ static void TEST7_G_ev2(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST7_S1;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST7_ROOT.InitialState
     } // end of behavior for TEST7_G
@@ -4592,7 +4593,7 @@ static void TEST7_S1_ev1(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST7_G_S1;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST7_G.InitialState
         
@@ -4610,7 +4611,7 @@ static void TEST7_S1_ev1(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST7_G_S2;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST7_G.InitialState
         
@@ -4627,7 +4628,7 @@ static void TEST7_S1_ev1(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST7_G_S3;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST7_G.InitialState
     } // end of behavior for TEST7_S1
@@ -4665,7 +4666,7 @@ static void TEST7_S1_ev3(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST7_G_S1;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST7_G.InitialState
         
@@ -4683,7 +4684,7 @@ static void TEST7_S1_ev3(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST7_G_S2;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST7_G.InitialState
         
@@ -4700,7 +4701,7 @@ static void TEST7_S1_ev3(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST7_G_S3;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST7_G.InitialState
     } // end of behavior for TEST7_S1
@@ -4746,6 +4747,7 @@ static void TEST8_ROOT_enter(Spec2Sm* self)
 {
     // setup trigger/event handlers
     self->current_state_exit_handler = TEST8_ROOT_exit;
+    self->current_event_handlers[Spec2Sm_EventId_EV3] = TEST8_ROOT_ev3;
     self->current_event_handlers[Spec2Sm_EventId_EV5] = TEST8_ROOT_ev5;
     
     // TEST8_ROOT behavior
@@ -4775,7 +4777,22 @@ static void TEST8_ROOT_exit(Spec2Sm* self)
     
     // adjust function pointers for this state's exit
     self->current_state_exit_handler = TEST8_ENTRY_CHOICE_exit;
+    self->current_event_handlers[Spec2Sm_EventId_EV3] = NULL;  // no ancestor listens to this event
     self->current_event_handlers[Spec2Sm_EventId_EV5] = NULL;  // no ancestor listens to this event
+}
+
+static void TEST8_ROOT_ev3(Spec2Sm* self)
+{
+    // No ancestor state handles `EV3` event.
+    
+    // TEST8_ROOT behavior
+    // uml: EV3 [trace_guard("State TEST8_ROOT: check behavior `EV3`.", true)]
+    if (trace_guard("State TEST8_ROOT: check behavior `EV3`.", true))
+    {
+        // Step 1: execute action ``
+        // Step 2: determine if ancestor gets to handle event next.
+        // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
+    } // end of behavior for TEST8_ROOT
 }
 
 static void TEST8_ROOT_ev5(Spec2Sm* self)
@@ -5075,7 +5092,7 @@ static void TEST8_S1_exit(Spec2Sm* self)
     // adjust function pointers for this state's exit
     self->current_state_exit_handler = TEST8_ROOT_exit;
     self->current_event_handlers[Spec2Sm_EventId_EV1] = NULL;  // no ancestor listens to this event
-    self->current_event_handlers[Spec2Sm_EventId_EV3] = NULL;  // no ancestor listens to this event
+    self->current_event_handlers[Spec2Sm_EventId_EV3] = TEST8_ROOT_ev3;  // the next ancestor that handles this event is TEST8_ROOT
     self->current_event_handlers[Spec2Sm_EventId_EV6] = NULL;  // no ancestor listens to this event
 }
 
@@ -5119,7 +5136,8 @@ static void TEST8_S1_ev1(Spec2Sm* self)
 
 static void TEST8_S1_ev3(Spec2Sm* self)
 {
-    // No ancestor state handles `EV3` event.
+    // Setup handler for next ancestor that listens to `EV3` event.
+    self->ancestor_event_handler = TEST8_ROOT_ev3;
     
     // TEST8_S1 behavior
     // uml: EV3 [trace_guard("State TEST8_S1: check behavior `EV3 TransitionTo(TEST8_G.EntryPoint(3))`.", true)] / { trace("Transition action `` for TEST8_S1 to TEST8_G.EntryPoint(3)."); } TransitionTo(TEST8_G.EntryPoint(3))
@@ -5272,7 +5290,7 @@ static void TEST9_DECIDE_ev1(Spec2Sm* self)
                 
                 // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
                 self->state_id = Spec2Sm_StateId_TEST9_S1_1;
-                self->ancestor_event_handler = NULL;
+                // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
                 return;
             } // end of behavior for TEST9_S1.InitialState
         } // end of behavior for TEST9_ROOT.InitialState
@@ -5321,7 +5339,7 @@ static void TEST9_DECIDE_ev2(Spec2Sm* self)
                 
                 // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
                 self->state_id = Spec2Sm_StateId_TEST9A_S1_1;
-                self->ancestor_event_handler = NULL;
+                // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
                 return;
             } // end of behavior for TEST9A_S1.InitialState
         } // end of behavior for TEST9A_ROOT.InitialState
@@ -5608,7 +5626,7 @@ static void TEST9_S1_1_ev1(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST9_G_S4;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST9_S1.ExitPoint(1)
         
@@ -5627,7 +5645,7 @@ static void TEST9_S1_1_ev1(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST9_G_S1;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST9_S1.ExitPoint(1)
         
@@ -5646,7 +5664,7 @@ static void TEST9_S1_1_ev1(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST9_G_S2;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST9_S1.ExitPoint(1)
         
@@ -5664,7 +5682,7 @@ static void TEST9_S1_1_ev1(Spec2Sm* self)
             
             // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
             self->state_id = Spec2Sm_StateId_TEST9_G_S3;
-            self->ancestor_event_handler = NULL;
+            // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
             return;
         } // end of behavior for TEST9_S1.ExitPoint(1)
     } // end of behavior for TEST9_S1_1
@@ -5824,7 +5842,7 @@ static void TEST9A_S1_1_ev1(Spec2Sm* self)
                 
                 // Step 4: complete transition. Ends event dispatch. No other behaviors are checked.
                 self->state_id = Spec2Sm_StateId_TEST9A_S1_1;
-                self->ancestor_event_handler = NULL;
+                // No ancestor handles event. Can skip nulling `self->ancestor_event_handler`.
                 return;
             } // end of behavior for TEST9A_S1.InitialState
         } // end of behavior for TEST9A_S1.ExitPoint(1)


### PR DESCRIPTION
Pretty handy in deeply nested state machines.

closes #14