### PR TITLE
Features/migrate dot net 8

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,13 +11,8 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
-    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       # required for all workflows
       security-events: write
@@ -51,19 +46,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
     - if: matrix.build-mode == 'manual'
       run: |
         dotnet build --configuration Debug --no-restore src/StateSmith.sln
@@ -71,4 +54,7 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:
+        upload: true
+        output: sarif-results
         category: "/language:${{matrix.language}}"
+        

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,72 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '45 0 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: csharp
+          build-mode: manual
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - if: matrix.build-mode == 'manual'
+      run: |
+        dotnet build --configuration Debug --no-restore src/StateSmith.sln
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,6 +42,8 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
+    - name: Install dependencies
+      run: dotnet restore src/StateSmith.sln
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
           node-version: latest
 
       - name: Setup .NET SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Display dotnet version

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        dotnet-version: ['6.0.x', '7.0.x', '8.0.x']        
+        dotnet-version: ['6.0.x', '7.0.x', '8.0.x']     
+        include:
+          - dotnet-version: 6.0.x
+            framework: net6.0
+          - dotnet-version: 7.0.x
+            framework: net7.0
+          - dotnet-version: 8.0.x
+            framework: net8.0
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -16,17 +24,11 @@ jobs:
         with:
           node-version: latest
 
-      - name: Setup .NET SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
-      - name: Display dotnet version
-        run: dotnet --version
       - name: Install dependencies
-        run: dotnet restore src/StateSmith.sln
+        run: dotnet restore -p:TargetFramework=${{ matrix.framework }} src/StateSmith.sln
 
-      - name: Build
-        run: dotnet build --configuration Debug --no-restore src/StateSmith.sln
+      - name: Build (${{ matrix.framework }})
+        run: dotnet build --framework ${{ matrix.framework }} --configuration Debug --no-restore src/StateSmith.sln
 
       - name: Test
-        run: dotnet test --no-restore src/StateSmith.sln
+        run: dotnet test --framework ${{ matrix.framework }} --no-restore src/StateSmith.sln

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,19 +4,22 @@ on: [push, pull_request]
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet: ['6.0.x', '7.0.x', '8.0.x']
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: latest
 
-      - name: Setup .NET SDK 6.0.x
-        uses: actions/setup-dotnet@v3
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: ${{ matrix.dotnet }}
 
       - name: Install dependencies
         run: dotnet restore src/StateSmith.sln

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,8 +6,8 @@ jobs:
   build:
     strategy:
       matrix:
-        dotnet: ['6.0.x', '7.0.x', '8.0.x']
         os: [ubuntu-latest, windows-latest, macos-latest]
+        dotnet: ['6.0.x', '7.0.x', '8.0.x']        
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
         dotnet: ['6.0.x', '7.0.x', '8.0.x']        
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,8 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        buildType: ['Debug', 'Release']
+        os: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -27,8 +26,8 @@ jobs:
       - name: Install dependencies
         run: dotnet restore src/StateSmith.sln
 
-      - name: Build (${{ matrix.framework }})
-        run: dotnet build --configuration ${{ matrix.buildType }} --no-restore src/StateSmith.sln
+      - name: Build
+        run: dotnet build --configuration Debug --no-restore src/StateSmith.sln
 
       - name: Test
         run: dotnet test --no-restore src/StateSmith.sln

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
           node-version: latest
 
       - name: Setup .NET SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v2
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Display dotnet version

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,15 +6,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        dotnet-version: ['6.0.x', '7.0.x', '8.0.x']     
-        include:
-          - dotnet-version: 6.0.x
-            framework: net6.0
-          - dotnet-version: 7.0.x
-            framework: net7.0
-          - dotnet-version: 8.0.x
-            framework: net8.0
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        buildType: ['Debug', 'Release']
 
     runs-on: ${{ matrix.os }}
 
@@ -25,10 +18,10 @@ jobs:
           node-version: latest
 
       - name: Install dependencies
-        run: dotnet restore -p:TargetFramework=${{ matrix.framework }} src/StateSmith.sln
+        run: dotnet restore src/StateSmith.sln
 
       - name: Build (${{ matrix.framework }})
-        run: dotnet build --framework ${{ matrix.framework }} --configuration Debug --no-restore src/StateSmith.sln
+        run: dotnet build --configuration ${{ matrix.buildType }} --no-restore src/StateSmith.sln
 
       - name: Test
-        run: dotnet test --framework ${{ matrix.framework }} --no-restore src/StateSmith.sln
+        run: dotnet test --no-restore src/StateSmith.sln

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: latest
-
+          
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
       - name: Install dependencies
         run: dotnet restore src/StateSmith.sln
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        dotnet: ['6.0.x', '7.0.x', '8.0.x']        
+        dotnet-version: ['6.0.x', '7.0.x', '8.0.x']        
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -16,11 +16,12 @@ jobs:
         with:
           node-version: latest
 
-      - name: Setup .NET SDK
+      - name: Setup .NET SDK ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ matrix.dotnet }}
-
+          dotnet-version: ${{ matrix.dotnet-version }}
+      - name: Display dotnet version
+        run: dotnet --version
       - name: Install dependencies
         run: dotnet restore src/StateSmith.sln
 

--- a/src/StateSmith.Cli/StateSmith.Cli.csproj
+++ b/src/StateSmith.Cli/StateSmith.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Version>0.7.1</Version>
     <Company>Adam Fraser-Kruck</Company>
     <Product>StateSmith</Product>

--- a/src/StateSmith.Cli/StateSmith.Cli.csproj
+++ b/src/StateSmith.Cli/StateSmith.Cli.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <Version>0.7.1</Version>
     <Company>Adam Fraser-Kruck</Company>
     <Product>StateSmith</Product>

--- a/src/StateSmith.CliTest/StateSmith.CliTest.csproj
+++ b/src/StateSmith.CliTest/StateSmith.CliTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/StateSmith/StateSmith.csproj
+++ b/src/StateSmith/StateSmith.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageId>StateSmith</PackageId>
     <Version>0.9.12-alpha</Version>
     <Authors>Adam Fraser-Kruck</Authors>

--- a/src/StateSmith/StateSmith.csproj
+++ b/src/StateSmith/StateSmith.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackageId>StateSmith</PackageId>
     <Version>0.9.12-alpha</Version>
     <Authors>Adam Fraser-Kruck</Authors>

--- a/src/StateSmithTest/StateSmithTest.csproj
+++ b/src/StateSmithTest/StateSmithTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
The project cli has 3 target framework (.net 6/7/8), but for other projects only 1 target is possible (sometime 6 or 7). It is impossible to build for the 3 targets with the sln. 
Moreover, the github action to setup dotnet use only latest version available

To keep consistency and use a LTS version use only 8 version