### PR TITLE
Show events in sidebar chronologically, and let user show/hide timestamps

### DIFF
--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -93,6 +93,13 @@ public class HtmlRenderer
         width: 100%;
       }
 
+      table.console td.timestamp {
+      }
+
+      table.console.timestamps td.timestamp {
+        display: none;
+      }
+
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;
@@ -193,7 +200,7 @@ public class HtmlRenderer
               </div>
             </div>            
             </div>
-            <table class=""console"">
+            <table class=""console timestamps"">
             <tbody>
             </tbody>
             </table>
@@ -254,13 +261,15 @@ public class HtmlRenderer
 
         gutter.addEventListener('mousedown', resizer);
 
+        document.getElementById('timestamps').checked = document.querySelector('table.console').classList.contains('timestamps');
         document.getElementById('timestamps').addEventListener('change', function() {
-          const showTimestamps = this.checked;
-          const timestamps = document.querySelectorAll('.timestamp');
-          for (const timestamp of timestamps) {
-            timestamp.style.display = showTimestamps ? 'table-cell' : 'none';
+          if(this.checked) {
+            document.querySelector('table.console').classList.add('timestamps');
+          } else {
+            document.querySelector('table.console').classList.remove('timestamps');
           }
         });
+
         document.getElementById('dropbtn').addEventListener('click', myFunction);
 
         /* When the user clicks on the button, 

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -115,8 +115,11 @@ public class HtmlRenderer
         font-family: monospace;
       }
 
-      .console td {
+      .console tr {
         border-bottom: 1px solid #ccc;
+      }
+
+      .console td {
         padding: 5px;
       }
   

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -150,7 +150,7 @@ public class HtmlRenderer
       }
 
       .dropbtn:hover, .dropbtn:focus {
-        background-color: #2980B9;
+        background-color: #f1f1f1;
       }
 
       .dropdown {
@@ -173,8 +173,6 @@ public class HtmlRenderer
         font-weight: normal;
       }
 
-      .dropdown a:hover {background-color: #ddd;}
-
       .show {display: block;}
     </style>
   </head>
@@ -195,7 +193,7 @@ public class HtmlRenderer
         <div class=""history"">
             <div class=""titlebar"">Log
             <div class='dropdown'>
-              <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
+              <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
               <div id='myDropdown' class='dropdown-content'>
                 <div class='dropdown-item'>
                   <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -162,6 +162,7 @@ public class HtmlRenderer
       .dropdown-content {
         display: none;
         position: absolute;
+        right: 0;
         background-color: #f1f1f1;
         min-width: 160px;
         overflow: auto;

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -157,11 +157,9 @@ public class HtmlRenderer
         z-index: 1;
       }
 
-      .dropdown-content a {
-        color: black;
+      .dropdown-content .dropdown-item {
         padding: 12px 16px;
-        text-decoration: none;
-        display: block;
+        font-weight: normal;
       }
 
       .dropdown a:hover {background-color: #ddd;}
@@ -188,7 +186,10 @@ public class HtmlRenderer
             <div class='dropdown'>
               <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
               <div id='myDropdown' class='dropdown-content'>
-                <a href='#home'>Display timestamps</a>
+                <div class='dropdown-item'>
+                  <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
+                  <label for=timestamps'>Timestamps</label>
+                </div>
               </div>
             </div>            
             </div>

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -47,6 +47,7 @@ public class HtmlRenderer
         font-size: 16px;
         color: #777;
         margin-left: auto;
+        border-radius: 5px;
       }
 
       .gutter {

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -94,10 +94,11 @@ public class HtmlRenderer
       }
 
       table.console td.timestamp {
+        display: none;
       }
 
       table.console.timestamps td.timestamp {
-        display: none;
+        display: table-cell;
       }
 
       .console th {
@@ -200,7 +201,7 @@ public class HtmlRenderer
               </div>
             </div>            
             </div>
-            <table class=""console timestamps"">
+            <table class=""console"">
             <tbody>
             </tbody>
             </table>

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -46,7 +46,6 @@ public class HtmlRenderer
         font-family: 'Material Symbols Outlined', sans-serif;
         font-size: 16px;
         color: #777;
-        margin-left: auto;
         border-radius: 5px;
       }
 
@@ -157,6 +156,7 @@ public class HtmlRenderer
       .dropdown {
         position: relative;
         display: inline-block;
+        margin-left: auto;
       }
 
       .dropdown-content {

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -67,6 +67,7 @@ public class HtmlRenderer
 
       .sidebar {
         width: 300px;
+        padding-top: 0px;
         position: relative;
         background-color: #f0f0f0;
         border-left: 1px solid #ccc;

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -132,6 +132,41 @@ public class HtmlRenderer
       button {
         margin: 5px;
       }
+
+      .dropbtn {
+        border: none;
+        cursor: pointer;
+      }
+
+      .dropbtn:hover, .dropbtn:focus {
+        background-color: #2980B9;
+      }
+
+      .dropdown {
+        position: relative;
+        display: inline-block;
+      }
+
+      .dropdown-content {
+        display: none;
+        position: absolute;
+        background-color: #f1f1f1;
+        min-width: 160px;
+        overflow: auto;
+        box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+        z-index: 1;
+      }
+
+      .dropdown-content a {
+        color: black;
+        padding: 12px 16px;
+        text-decoration: none;
+        display: block;
+      }
+
+      .dropdown a:hover {background-color: #ddd;}
+
+      .show {display: block;}
     </style>
   </head>
 
@@ -149,7 +184,14 @@ public class HtmlRenderer
         </div>
 
         <div class=""history"">
-            <div class=""titlebar"">Log <span class='titlebar-icon'>settings</span></div>
+            <div class=""titlebar"">Log
+            <div class='dropdown'>
+              <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
+              <div id='myDropdown' class='dropdown-content'>
+                <a href='#home'>Display timestamps</a>
+              </div>
+            </div>            
+            </div>
             <table class=""console"">
             <tbody>
             </tbody>
@@ -210,6 +252,29 @@ public class HtmlRenderer
         }
 
         gutter.addEventListener('mousedown', resizer);
+
+        document.getElementById('dropbtn').addEventListener('click', myFunction);
+
+        /* When the user clicks on the button, 
+        toggle between hiding and showing the dropdown content */
+        function myFunction() {
+          document.getElementById('myDropdown').classList.add('show');
+        }
+
+        // Close the dropdown if the user clicks outside of it
+        window.onclick = function(event) {
+          if (!event.target.matches('.dropbtn')) {
+            var dropdowns = document.getElementsByClassName('dropdown-content');
+            var i;
+            for (i = 0; i < dropdowns.length; i++) {
+              var openDropdown = dropdowns[i];
+              if (openDropdown.classList.contains('show')) {
+                openDropdown.classList.remove('show');
+              }
+            }
+          }
+        }
+
 
 {{mocksCode}}
 

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -196,7 +196,7 @@ public class HtmlRenderer
                 <div id='myDropdown' class='dropdown-content'>
                   <div class='dropdown-item'>
                     <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
-                    <label for=timestamps'>Timestamps</label>
+                    <label for='timestamps'>Timestamps</label>
                   </div>
                 </div>
               </div>            

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -189,25 +189,24 @@ public class HtmlRenderer
 
     <div class=""pane sidebar"">
         <div id=""buttons"">
-            <div class=""titlebar"">Events</div>
+            <div class=""titlebar"">Events            
+              <div class='dropdown'>
+                <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
+                <div id='myDropdown' class='dropdown-content'>
+                  <div class='dropdown-item'>
+                    <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
+                    <label for=timestamps'>Timestamps</label>
+                  </div>
+                </div>
+              </div>            
+          </div>
         </div>
 
         <div class=""history"">
-            <div class=""titlebar"">Log
-            <div class='dropdown'>
-              <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
-              <div id='myDropdown' class='dropdown-content'>
-                <div class='dropdown-item'>
-                  <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
-                  <label for=timestamps'>Timestamps</label>
-                </div>
-              </div>
-            </div>            
-            </div>
-            <table class=""console"">
-              <tbody>
-              </tbody>
-            </table>
+          <table class=""console"">
+            <tbody>
+            </tbody>
+          </table>
         </div>
 
         <div class=""gutter""></div>

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -23,6 +23,7 @@ public class HtmlRenderer
   -->
 <html>
   <head>
+    <link rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined'>
     <style>
       body {
         display: flex;
@@ -39,6 +40,13 @@ public class HtmlRenderer
       .pane {
         padding: 1em;
         min-width: 200px;
+      }
+
+      .titlebar-icon {
+        font-family: 'Material Symbols Outlined', sans-serif;
+        font-size: 16px;
+        color: #777;
+        margin-left: auto;
       }
 
       .gutter {
@@ -76,6 +84,7 @@ public class HtmlRenderer
         border-bottom: 1px solid #ccc;
         font-weight: bold;
         padding: 5px;
+        display: flex;
       }
 
       .console {
@@ -140,7 +149,7 @@ public class HtmlRenderer
         </div>
 
         <div class=""history"">
-            <div class=""titlebar"">Log</div>
+            <div class=""titlebar"">Log <span class='titlebar-icon'>settings</span></div>
             <table class=""console"">
             <tbody>
             </tbody>

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -258,7 +258,7 @@ public class HtmlRenderer
         /* When the user clicks on the button, 
         toggle between hiding and showing the dropdown content */
         function myFunction() {
-          document.getElementById('myDropdown').classList.add('show');
+          document.getElementById('myDropdown').classList.toggle('show');
         }
 
         // Close the dropdown if the user clicks outside of it

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -110,8 +110,6 @@ public class HtmlRenderer
       }
 
       .console tbody {
-        display: flex;
-        flex-direction: column-reverse;
         font-family: monospace;
       }
 
@@ -132,8 +130,10 @@ public class HtmlRenderer
       }
 
       .history {
-        margin-top: 30px;
+        margin-top: 30px;       
+        display: flex;
         overflow: scroll;    
+        flex-direction: column-reverse;
       }
 
       .console tr:last-child td {
@@ -205,8 +205,8 @@ public class HtmlRenderer
             </div>            
             </div>
             <table class=""console"">
-            <tbody>
-            </tbody>
+              <tbody>
+              </tbody>
             </table>
         </div>
 

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -132,7 +132,7 @@ public class HtmlRenderer
       .history {
         margin-top: 30px;       
         display: flex;
-        overflow: scroll;    
+        overflow: auto;    
         flex-direction: column-reverse;
       }
 

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -254,6 +254,13 @@ public class HtmlRenderer
 
         gutter.addEventListener('mousedown', resizer);
 
+        document.getElementById('timestamps').addEventListener('change', function() {
+          const showTimestamps = this.checked;
+          const timestamps = document.querySelectorAll('.timestamp');
+          for (const timestamp of timestamps) {
+            timestamp.style.display = showTimestamps ? 'table-cell' : 'none';
+          }
+        });
         document.getElementById('dropbtn').addEventListener('click', myFunction);
 
         /* When the user clicks on the button, 

--- a/src/StateSmithTest/Output/Sim/SimWebGeneratorTest.cs
+++ b/src/StateSmithTest/Output/Sim/SimWebGeneratorTest.cs
@@ -2,7 +2,6 @@ using StateSmith.Common;
 using StateSmith.Output;
 using StateSmith.Output.Sim;
 using StateSmith.Runner;
-using System;
 using System.IO;
 using Xunit;
 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -35,7 +35,6 @@
         font-family: 'Material Symbols Outlined', sans-serif;
         font-size: 16px;
         color: #777;
-        margin-left: auto;
         border-radius: 5px;
       }
 
@@ -146,6 +145,7 @@
       .dropdown {
         position: relative;
         display: inline-block;
+        margin-left: auto;
       }
 
       .dropdown-content {

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -121,6 +121,41 @@
       button {
         margin: 5px;
       }
+
+      .dropbtn {
+        border: none;
+        cursor: pointer;
+      }
+
+      .dropbtn:hover, .dropbtn:focus {
+        background-color: #2980B9;
+      }
+
+      .dropdown {
+        position: relative;
+        display: inline-block;
+      }
+
+      .dropdown-content {
+        display: none;
+        position: absolute;
+        background-color: #f1f1f1;
+        min-width: 160px;
+        overflow: auto;
+        box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+        z-index: 1;
+      }
+
+      .dropdown-content a {
+        color: black;
+        padding: 12px 16px;
+        text-decoration: none;
+        display: block;
+      }
+
+      .dropdown a:hover {background-color: #ddd;}
+
+      .show {display: block;}
     </style>
   </head>
 
@@ -166,7 +201,14 @@ OFF --> ON1 : INCREASE
         </div>
 
         <div class="history">
-            <div class="titlebar">Log <span class='titlebar-icon'>settings</span></div>
+            <div class="titlebar">Log
+            <div class='dropdown'>
+              <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
+              <div id='myDropdown' class='dropdown-content'>
+                <a href='#home'>Display timestamps</a>
+              </div>
+            </div>            
+            </div>
             <table class="console">
             <tbody>
             </tbody>
@@ -748,6 +790,29 @@ evaluateGuard = null;
         }
 
         gutter.addEventListener('mousedown', resizer);
+
+        document.getElementById('dropbtn').addEventListener('click', myFunction);
+
+        /* When the user clicks on the button, 
+        toggle between hiding and showing the dropdown content */
+        function myFunction() {
+          document.getElementById('myDropdown').classList.add('show');
+        }
+
+        // Close the dropdown if the user clicks outside of it
+        window.onclick = function(event) {
+          if (!event.target.matches('.dropbtn')) {
+            var dropdowns = document.getElementsByClassName('dropdown-content');
+            var i;
+            for (i = 0; i < dropdowns.length; i++) {
+              var openDropdown = dropdowns[i];
+              if (openDropdown.classList.contains('show')) {
+                openDropdown.classList.remove('show');
+              }
+            }
+          }
+        }
+
 
 
 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -146,11 +146,9 @@
         z-index: 1;
       }
 
-      .dropdown-content a {
-        color: black;
+      .dropdown-content .dropdown-item {
         padding: 12px 16px;
-        text-decoration: none;
-        display: block;
+        font-weight: normal;
       }
 
       .dropdown a:hover {background-color: #ddd;}
@@ -205,7 +203,10 @@ OFF --> ON1 : INCREASE
             <div class='dropdown'>
               <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
               <div id='myDropdown' class='dropdown-content'>
-                <a href='#home'>Display timestamps</a>
+                <div class='dropdown-item'>
+                  <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
+                  <label for=timestamps'>Timestamps</label>
+                </div>
               </div>
             </div>            
             </div>

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -82,6 +82,13 @@
         width: 100%;
       }
 
+      table.console td.timestamp {
+      }
+
+      table.console.timestamps td.timestamp {
+        display: none;
+      }
+
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;
@@ -210,7 +217,7 @@ OFF --> ON1 : INCREASE
               </div>
             </div>            
             </div>
-            <table class="console">
+            <table class="console timestamps">
             <tbody>
             </tbody>
             </table>
@@ -792,13 +799,15 @@ evaluateGuard = null;
 
         gutter.addEventListener('mousedown', resizer);
 
+        document.getElementById('timestamps').checked = document.querySelector('table.console').classList.contains('timestamps');
         document.getElementById('timestamps').addEventListener('change', function() {
-          const showTimestamps = this.checked;
-          const timestamps = document.querySelectorAll('.timestamp');
-          for (const timestamp of timestamps) {
-            timestamp.style.display = showTimestamps ? 'table-cell' : 'none';
+          if(this.checked) {
+            document.querySelector('table.console').classList.add('timestamps');
+          } else {
+            document.querySelector('table.console').classList.remove('timestamps');
           }
         });
+
         document.getElementById('dropbtn').addEventListener('click', myFunction);
 
         /* When the user clicks on the button, 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -129,6 +129,10 @@
         border-bottom: none;
       }
 
+      button {
+        margin: 5px;
+      }
+
       .dropbtn {
         border: none;
         cursor: pointer;

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -36,6 +36,7 @@
         font-size: 16px;
         color: #777;
         margin-left: auto;
+        border-radius: 5px;
       }
 
       .gutter {

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -206,25 +206,24 @@ OFF --> ON1 : INCREASE
 
     <div class="pane sidebar">
         <div id="buttons">
-            <div class="titlebar">Events</div>
+            <div class="titlebar">Events            
+              <div class='dropdown'>
+                <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
+                <div id='myDropdown' class='dropdown-content'>
+                  <div class='dropdown-item'>
+                    <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
+                    <label for=timestamps'>Timestamps</label>
+                  </div>
+                </div>
+              </div>            
+          </div>
         </div>
 
         <div class="history">
-            <div class="titlebar">Log
-            <div class='dropdown'>
-              <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
-              <div id='myDropdown' class='dropdown-content'>
-                <div class='dropdown-item'>
-                  <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
-                  <label for=timestamps'>Timestamps</label>
-                </div>
-              </div>
-            </div>            
-            </div>
-            <table class="console">
-              <tbody>
-              </tbody>
-            </table>
+          <table class="console">
+            <tbody>
+            </tbody>
+          </table>
         </div>
 
         <div class="gutter"></div>

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -12,6 +12,7 @@
   -->
 <html>
   <head>
+    <link rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined'>
     <style>
       body {
         display: flex;
@@ -28,6 +29,13 @@
       .pane {
         padding: 1em;
         min-width: 200px;
+      }
+
+      .titlebar-icon {
+        font-family: 'Material Symbols Outlined', sans-serif;
+        font-size: 16px;
+        color: #777;
+        margin-left: auto;
       }
 
       .gutter {
@@ -65,6 +73,7 @@
         border-bottom: 1px solid #ccc;
         font-weight: bold;
         padding: 5px;
+        display: flex;
       }
 
       .console {
@@ -157,7 +166,7 @@ OFF --> ON1 : INCREASE
         </div>
 
         <div class="history">
-            <div class="titlebar">Log</div>
+            <div class="titlebar">Log <span class='titlebar-icon'>settings</span></div>
             <table class="console">
             <tbody>
             </tbody>

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -792,6 +792,13 @@ evaluateGuard = null;
 
         gutter.addEventListener('mousedown', resizer);
 
+        document.getElementById('timestamps').addEventListener('change', function() {
+          const showTimestamps = this.checked;
+          const timestamps = document.querySelectorAll('.timestamp');
+          for (const timestamp of timestamps) {
+            timestamp.style.display = showTimestamps ? 'table-cell' : 'none';
+          }
+        });
         document.getElementById('dropbtn').addEventListener('click', myFunction);
 
         /* When the user clicks on the button, 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -99,8 +99,6 @@
       }
 
       .console tbody {
-        display: flex;
-        flex-direction: column-reverse;
         font-family: monospace;
       }
 
@@ -121,8 +119,10 @@
       }
 
       .history {
-        margin-top: 30px;
+        margin-top: 30px;       
+        display: flex;
         overflow: scroll;    
+        flex-direction: column-reverse;
       }
 
       .console tr:last-child td {
@@ -222,8 +222,8 @@ OFF --> ON1 : INCREASE
             </div>            
             </div>
             <table class="console">
-            <tbody>
-            </tbody>
+              <tbody>
+              </tbody>
             </table>
         </div>
 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -104,8 +104,11 @@
         font-family: monospace;
       }
 
-      .console td {
+      .console tr {
         border-bottom: 1px solid #ccc;
+      }
+
+      .console td {
         padding: 5px;
       }
   

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -83,10 +83,11 @@
       }
 
       table.console td.timestamp {
+        display: none;
       }
 
       table.console.timestamps td.timestamp {
-        display: none;
+        display: table-cell;
       }
 
       .console th {
@@ -217,7 +218,7 @@ OFF --> ON1 : INCREASE
               </div>
             </div>            
             </div>
-            <table class="console timestamps">
+            <table class="console">
             <tbody>
             </tbody>
             </table>

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -129,17 +129,13 @@
         border-bottom: none;
       }
 
-      button {
-        margin: 5px;
-      }
-
       .dropbtn {
         border: none;
         cursor: pointer;
       }
 
       .dropbtn:hover, .dropbtn:focus {
-        background-color: #2980B9;
+        background-color: #f1f1f1;
       }
 
       .dropdown {
@@ -161,8 +157,6 @@
         padding: 12px 16px;
         font-weight: normal;
       }
-
-      .dropdown a:hover {background-color: #ddd;}
 
       .show {display: block;}
     </style>
@@ -212,7 +206,7 @@ OFF --> ON1 : INCREASE
         <div class="history">
             <div class="titlebar">Log
             <div class='dropdown'>
-              <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
+              <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
               <div id='myDropdown' class='dropdown-content'>
                 <div class='dropdown-item'>
                   <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -213,7 +213,7 @@ OFF --> ON1 : INCREASE
                 <div id='myDropdown' class='dropdown-content'>
                   <div class='dropdown-item'>
                     <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
-                    <label for=timestamps'>Timestamps</label>
+                    <label for='timestamps'>Timestamps</label>
                   </div>
                 </div>
               </div>            

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -56,6 +56,7 @@
 
       .sidebar {
         width: 300px;
+        padding-top: 0px;
         position: relative;
         background-color: #f0f0f0;
         border-left: 1px solid #ccc;

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -121,7 +121,7 @@
       .history {
         margin-top: 30px;       
         display: flex;
-        overflow: scroll;    
+        overflow: auto;    
         flex-direction: column-reverse;
       }
 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -796,7 +796,7 @@ evaluateGuard = null;
         /* When the user clicks on the button, 
         toggle between hiding and showing the dropdown content */
         function myFunction() {
-          document.getElementById('myDropdown').classList.add('show');
+          document.getElementById('myDropdown').classList.toggle('show');
         }
 
         // Close the dropdown if the user clicks outside of it

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -151,6 +151,7 @@
       .dropdown-content {
         display: none;
         position: absolute;
+        right: 0;
         background-color: #f1f1f1;
         min-width: 160px;
         overflow: auto;

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -35,7 +35,6 @@
         font-family: 'Material Symbols Outlined', sans-serif;
         font-size: 16px;
         color: #777;
-        margin-left: auto;
         border-radius: 5px;
       }
 
@@ -146,6 +145,7 @@
       .dropdown {
         position: relative;
         display: inline-block;
+        margin-left: auto;
       }
 
       .dropdown-content {

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -230,25 +230,24 @@ ROOT.(InitialState) --> WAITING
 
     <div class="pane sidebar">
         <div id="buttons">
-            <div class="titlebar">Events</div>
+            <div class="titlebar">Events            
+              <div class='dropdown'>
+                <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
+                <div id='myDropdown' class='dropdown-content'>
+                  <div class='dropdown-item'>
+                    <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
+                    <label for=timestamps'>Timestamps</label>
+                  </div>
+                </div>
+              </div>            
+          </div>
         </div>
 
         <div class="history">
-            <div class="titlebar">Log
-            <div class='dropdown'>
-              <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
-              <div id='myDropdown' class='dropdown-content'>
-                <div class='dropdown-item'>
-                  <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
-                  <label for=timestamps'>Timestamps</label>
-                </div>
-              </div>
-            </div>            
-            </div>
-            <table class="console">
-              <tbody>
-              </tbody>
-            </table>
+          <table class="console">
+            <tbody>
+            </tbody>
+          </table>
         </div>
 
         <div class="gutter"></div>

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -237,7 +237,7 @@ ROOT.(InitialState) --> WAITING
                 <div id='myDropdown' class='dropdown-content'>
                   <div class='dropdown-item'>
                     <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
-                    <label for=timestamps'>Timestamps</label>
+                    <label for='timestamps'>Timestamps</label>
                   </div>
                 </div>
               </div>            

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -129,6 +129,10 @@
         border-bottom: none;
       }
 
+      button {
+        margin: 5px;
+      }
+
       .dropbtn {
         border: none;
         cursor: pointer;

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -36,6 +36,7 @@
         font-size: 16px;
         color: #777;
         margin-left: auto;
+        border-radius: 5px;
       }
 
       .gutter {

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -12,6 +12,7 @@
   -->
 <html>
   <head>
+    <link rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined'>
     <style>
       body {
         display: flex;
@@ -28,6 +29,13 @@
       .pane {
         padding: 1em;
         min-width: 200px;
+      }
+
+      .titlebar-icon {
+        font-family: 'Material Symbols Outlined', sans-serif;
+        font-size: 16px;
+        color: #777;
+        margin-left: auto;
       }
 
       .gutter {
@@ -65,6 +73,7 @@
         border-bottom: 1px solid #ccc;
         font-weight: bold;
         padding: 5px;
+        display: flex;
       }
 
       .console {
@@ -112,6 +121,41 @@
       button {
         margin: 5px;
       }
+
+      .dropbtn {
+        border: none;
+        cursor: pointer;
+      }
+
+      .dropbtn:hover, .dropbtn:focus {
+        background-color: #2980B9;
+      }
+
+      .dropdown {
+        position: relative;
+        display: inline-block;
+      }
+
+      .dropdown-content {
+        display: none;
+        position: absolute;
+        background-color: #f1f1f1;
+        min-width: 160px;
+        overflow: auto;
+        box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+        z-index: 1;
+      }
+
+      .dropdown-content a {
+        color: black;
+        padding: 12px 16px;
+        text-decoration: none;
+        display: block;
+      }
+
+      .dropdown a:hover {background-color: #ddd;}
+
+      .show {display: block;}
     </style>
   </head>
 
@@ -181,7 +225,14 @@ ROOT.(InitialState) --> WAITING
         </div>
 
         <div class="history">
-            <div class="titlebar">Log</div>
+            <div class="titlebar">Log
+            <div class='dropdown'>
+              <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
+              <div id='myDropdown' class='dropdown-content'>
+                <a href='#home'>Display timestamps</a>
+              </div>
+            </div>            
+            </div>
             <table class="console">
             <tbody>
             </tbody>
@@ -1243,6 +1294,29 @@ evaluateGuard = null;
         }
 
         gutter.addEventListener('mousedown', resizer);
+
+        document.getElementById('dropbtn').addEventListener('click', myFunction);
+
+        /* When the user clicks on the button, 
+        toggle between hiding and showing the dropdown content */
+        function myFunction() {
+          document.getElementById('myDropdown').classList.add('show');
+        }
+
+        // Close the dropdown if the user clicks outside of it
+        window.onclick = function(event) {
+          if (!event.target.matches('.dropbtn')) {
+            var dropdowns = document.getElementsByClassName('dropdown-content');
+            var i;
+            for (i = 0; i < dropdowns.length; i++) {
+              var openDropdown = dropdowns[i];
+              if (openDropdown.classList.contains('show')) {
+                openDropdown.classList.remove('show');
+              }
+            }
+          }
+        }
+
 
 
 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -146,11 +146,9 @@
         z-index: 1;
       }
 
-      .dropdown-content a {
-        color: black;
+      .dropdown-content .dropdown-item {
         padding: 12px 16px;
-        text-decoration: none;
-        display: block;
+        font-weight: normal;
       }
 
       .dropdown a:hover {background-color: #ddd;}
@@ -229,7 +227,10 @@ ROOT.(InitialState) --> WAITING
             <div class='dropdown'>
               <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
               <div id='myDropdown' class='dropdown-content'>
-                <a href='#home'>Display timestamps</a>
+                <div class='dropdown-item'>
+                  <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
+                  <label for=timestamps'>Timestamps</label>
+                </div>
               </div>
             </div>            
             </div>

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -104,8 +104,11 @@
         font-family: monospace;
       }
 
-      .console td {
+      .console tr {
         border-bottom: 1px solid #ccc;
+      }
+
+      .console td {
         padding: 5px;
       }
   

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -1300,7 +1300,7 @@ evaluateGuard = null;
         /* When the user clicks on the button, 
         toggle between hiding and showing the dropdown content */
         function myFunction() {
-          document.getElementById('myDropdown').classList.add('show');
+          document.getElementById('myDropdown').classList.toggle('show');
         }
 
         // Close the dropdown if the user clicks outside of it

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -83,10 +83,11 @@
       }
 
       table.console td.timestamp {
+        display: none;
       }
 
       table.console.timestamps td.timestamp {
-        display: none;
+        display: table-cell;
       }
 
       .console th {
@@ -241,7 +242,7 @@ ROOT.(InitialState) --> WAITING
               </div>
             </div>            
             </div>
-            <table class="console timestamps">
+            <table class="console">
             <tbody>
             </tbody>
             </table>

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -82,6 +82,13 @@
         width: 100%;
       }
 
+      table.console td.timestamp {
+      }
+
+      table.console.timestamps td.timestamp {
+        display: none;
+      }
+
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;
@@ -234,7 +241,7 @@ ROOT.(InitialState) --> WAITING
               </div>
             </div>            
             </div>
-            <table class="console">
+            <table class="console timestamps">
             <tbody>
             </tbody>
             </table>
@@ -1296,13 +1303,15 @@ evaluateGuard = null;
 
         gutter.addEventListener('mousedown', resizer);
 
+        document.getElementById('timestamps').checked = document.querySelector('table.console').classList.contains('timestamps');
         document.getElementById('timestamps').addEventListener('change', function() {
-          const showTimestamps = this.checked;
-          const timestamps = document.querySelectorAll('.timestamp');
-          for (const timestamp of timestamps) {
-            timestamp.style.display = showTimestamps ? 'table-cell' : 'none';
+          if(this.checked) {
+            document.querySelector('table.console').classList.add('timestamps');
+          } else {
+            document.querySelector('table.console').classList.remove('timestamps');
           }
         });
+
         document.getElementById('dropbtn').addEventListener('click', myFunction);
 
         /* When the user clicks on the button, 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -1296,6 +1296,13 @@ evaluateGuard = null;
 
         gutter.addEventListener('mousedown', resizer);
 
+        document.getElementById('timestamps').addEventListener('change', function() {
+          const showTimestamps = this.checked;
+          const timestamps = document.querySelectorAll('.timestamp');
+          for (const timestamp of timestamps) {
+            timestamp.style.display = showTimestamps ? 'table-cell' : 'none';
+          }
+        });
         document.getElementById('dropbtn').addEventListener('click', myFunction);
 
         /* When the user clicks on the button, 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -129,17 +129,13 @@
         border-bottom: none;
       }
 
-      button {
-        margin: 5px;
-      }
-
       .dropbtn {
         border: none;
         cursor: pointer;
       }
 
       .dropbtn:hover, .dropbtn:focus {
-        background-color: #2980B9;
+        background-color: #f1f1f1;
       }
 
       .dropdown {
@@ -161,8 +157,6 @@
         padding: 12px 16px;
         font-weight: normal;
       }
-
-      .dropdown a:hover {background-color: #ddd;}
 
       .show {display: block;}
     </style>
@@ -236,7 +230,7 @@ ROOT.(InitialState) --> WAITING
         <div class="history">
             <div class="titlebar">Log
             <div class='dropdown'>
-              <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
+              <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
               <div id='myDropdown' class='dropdown-content'>
                 <div class='dropdown-item'>
                   <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -56,6 +56,7 @@
 
       .sidebar {
         width: 300px;
+        padding-top: 0px;
         position: relative;
         background-color: #f0f0f0;
         border-left: 1px solid #ccc;

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -99,8 +99,6 @@
       }
 
       .console tbody {
-        display: flex;
-        flex-direction: column-reverse;
         font-family: monospace;
       }
 
@@ -121,8 +119,10 @@
       }
 
       .history {
-        margin-top: 30px;
+        margin-top: 30px;       
+        display: flex;
         overflow: scroll;    
+        flex-direction: column-reverse;
       }
 
       .console tr:last-child td {
@@ -246,8 +246,8 @@ ROOT.(InitialState) --> WAITING
             </div>            
             </div>
             <table class="console">
-            <tbody>
-            </tbody>
+              <tbody>
+              </tbody>
             </table>
         </div>
 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -121,7 +121,7 @@
       .history {
         margin-top: 30px;       
         display: flex;
-        overflow: scroll;    
+        overflow: auto;    
         flex-direction: column-reverse;
       }
 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -151,6 +151,7 @@
       .dropdown-content {
         display: none;
         position: absolute;
+        right: 0;
         background-color: #f1f1f1;
         min-width: 160px;
         overflow: auto;

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -146,11 +146,9 @@
         z-index: 1;
       }
 
-      .dropdown-content a {
-        color: black;
+      .dropdown-content .dropdown-item {
         padding: 12px 16px;
-        text-decoration: none;
-        display: block;
+        font-weight: normal;
       }
 
       .dropdown a:hover {background-color: #ddd;}
@@ -208,7 +206,10 @@ State1 --> State2 : Ev2
             <div class='dropdown'>
               <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
               <div id='myDropdown' class='dropdown-content'>
-                <a href='#home'>Display timestamps</a>
+                <div class='dropdown-item'>
+                  <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
+                  <label for=timestamps'>Timestamps</label>
+                </div>
               </div>
             </div>            
             </div>

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -35,7 +35,6 @@
         font-family: 'Material Symbols Outlined', sans-serif;
         font-size: 16px;
         color: #777;
-        margin-left: auto;
         border-radius: 5px;
       }
 
@@ -146,6 +145,7 @@
       .dropdown {
         position: relative;
         display: inline-block;
+        margin-left: auto;
       }
 
       .dropdown-content {

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -12,6 +12,7 @@
   -->
 <html>
   <head>
+    <link rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined'>
     <style>
       body {
         display: flex;
@@ -28,6 +29,13 @@
       .pane {
         padding: 1em;
         min-width: 200px;
+      }
+
+      .titlebar-icon {
+        font-family: 'Material Symbols Outlined', sans-serif;
+        font-size: 16px;
+        color: #777;
+        margin-left: auto;
       }
 
       .gutter {
@@ -65,6 +73,7 @@
         border-bottom: 1px solid #ccc;
         font-weight: bold;
         padding: 5px;
+        display: flex;
       }
 
       .console {
@@ -112,6 +121,41 @@
       button {
         margin: 5px;
       }
+
+      .dropbtn {
+        border: none;
+        cursor: pointer;
+      }
+
+      .dropbtn:hover, .dropbtn:focus {
+        background-color: #2980B9;
+      }
+
+      .dropdown {
+        position: relative;
+        display: inline-block;
+      }
+
+      .dropdown-content {
+        display: none;
+        position: absolute;
+        background-color: #f1f1f1;
+        min-width: 160px;
+        overflow: auto;
+        box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+        z-index: 1;
+      }
+
+      .dropdown-content a {
+        color: black;
+        padding: 12px 16px;
+        text-decoration: none;
+        display: block;
+      }
+
+      .dropdown a:hover {background-color: #ddd;}
+
+      .show {display: block;}
     </style>
   </head>
 
@@ -160,7 +204,14 @@ State1 --> State2 : Ev2
         </div>
 
         <div class="history">
-            <div class="titlebar">Log</div>
+            <div class="titlebar">Log
+            <div class='dropdown'>
+              <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
+              <div id='myDropdown' class='dropdown-content'>
+                <a href='#home'>Display timestamps</a>
+              </div>
+            </div>            
+            </div>
             <table class="console">
             <tbody>
             </tbody>
@@ -776,6 +827,29 @@ evaluateGuard = null;
         }
 
         gutter.addEventListener('mousedown', resizer);
+
+        document.getElementById('dropbtn').addEventListener('click', myFunction);
+
+        /* When the user clicks on the button, 
+        toggle between hiding and showing the dropdown content */
+        function myFunction() {
+          document.getElementById('myDropdown').classList.add('show');
+        }
+
+        // Close the dropdown if the user clicks outside of it
+        window.onclick = function(event) {
+          if (!event.target.matches('.dropbtn')) {
+            var dropdowns = document.getElementsByClassName('dropdown-content');
+            var i;
+            for (i = 0; i < dropdowns.length; i++) {
+              var openDropdown = dropdowns[i];
+              if (openDropdown.classList.contains('show')) {
+                openDropdown.classList.remove('show');
+              }
+            }
+          }
+        }
+
 
 
 

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -129,6 +129,10 @@
         border-bottom: none;
       }
 
+      button {
+        margin: 5px;
+      }
+
       .dropbtn {
         border: none;
         cursor: pointer;

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -99,8 +99,6 @@
       }
 
       .console tbody {
-        display: flex;
-        flex-direction: column-reverse;
         font-family: monospace;
       }
 
@@ -121,8 +119,10 @@
       }
 
       .history {
-        margin-top: 30px;
+        margin-top: 30px;       
+        display: flex;
         overflow: scroll;    
+        flex-direction: column-reverse;
       }
 
       .console tr:last-child td {
@@ -225,8 +225,8 @@ State1 --> State2 : Ev2
             </div>            
             </div>
             <table class="console">
-            <tbody>
-            </tbody>
+              <tbody>
+              </tbody>
             </table>
         </div>
 

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -36,6 +36,7 @@
         font-size: 16px;
         color: #777;
         margin-left: auto;
+        border-radius: 5px;
       }
 
       .gutter {

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -833,7 +833,7 @@ evaluateGuard = null;
         /* When the user clicks on the button, 
         toggle between hiding and showing the dropdown content */
         function myFunction() {
-          document.getElementById('myDropdown').classList.add('show');
+          document.getElementById('myDropdown').classList.toggle('show');
         }
 
         // Close the dropdown if the user clicks outside of it

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -82,6 +82,13 @@
         width: 100%;
       }
 
+      table.console td.timestamp {
+      }
+
+      table.console.timestamps td.timestamp {
+        display: none;
+      }
+
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;
@@ -213,7 +220,7 @@ State1 --> State2 : Ev2
               </div>
             </div>            
             </div>
-            <table class="console">
+            <table class="console timestamps">
             <tbody>
             </tbody>
             </table>
@@ -829,13 +836,15 @@ evaluateGuard = null;
 
         gutter.addEventListener('mousedown', resizer);
 
+        document.getElementById('timestamps').checked = document.querySelector('table.console').classList.contains('timestamps');
         document.getElementById('timestamps').addEventListener('change', function() {
-          const showTimestamps = this.checked;
-          const timestamps = document.querySelectorAll('.timestamp');
-          for (const timestamp of timestamps) {
-            timestamp.style.display = showTimestamps ? 'table-cell' : 'none';
+          if(this.checked) {
+            document.querySelector('table.console').classList.add('timestamps');
+          } else {
+            document.querySelector('table.console').classList.remove('timestamps');
           }
         });
+
         document.getElementById('dropbtn').addEventListener('click', myFunction);
 
         /* When the user clicks on the button, 

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -104,8 +104,11 @@
         font-family: monospace;
       }
 
-      .console td {
+      .console tr {
         border-bottom: 1px solid #ccc;
+      }
+
+      .console td {
         padding: 5px;
       }
   

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -209,25 +209,24 @@ State1 --> State2 : Ev2
 
     <div class="pane sidebar">
         <div id="buttons">
-            <div class="titlebar">Events</div>
+            <div class="titlebar">Events            
+              <div class='dropdown'>
+                <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
+                <div id='myDropdown' class='dropdown-content'>
+                  <div class='dropdown-item'>
+                    <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
+                    <label for=timestamps'>Timestamps</label>
+                  </div>
+                </div>
+              </div>            
+          </div>
         </div>
 
         <div class="history">
-            <div class="titlebar">Log
-            <div class='dropdown'>
-              <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
-              <div id='myDropdown' class='dropdown-content'>
-                <div class='dropdown-item'>
-                  <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
-                  <label for=timestamps'>Timestamps</label>
-                </div>
-              </div>
-            </div>            
-            </div>
-            <table class="console">
-              <tbody>
-              </tbody>
-            </table>
+          <table class="console">
+            <tbody>
+            </tbody>
+          </table>
         </div>
 
         <div class="gutter"></div>

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -216,7 +216,7 @@ State1 --> State2 : Ev2
                 <div id='myDropdown' class='dropdown-content'>
                   <div class='dropdown-item'>
                     <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
-                    <label for=timestamps'>Timestamps</label>
+                    <label for='timestamps'>Timestamps</label>
                   </div>
                 </div>
               </div>            

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -56,6 +56,7 @@
 
       .sidebar {
         width: 300px;
+        padding-top: 0px;
         position: relative;
         background-color: #f0f0f0;
         border-left: 1px solid #ccc;

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -129,17 +129,13 @@
         border-bottom: none;
       }
 
-      button {
-        margin: 5px;
-      }
-
       .dropbtn {
         border: none;
         cursor: pointer;
       }
 
       .dropbtn:hover, .dropbtn:focus {
-        background-color: #2980B9;
+        background-color: #f1f1f1;
       }
 
       .dropdown {
@@ -161,8 +157,6 @@
         padding: 12px 16px;
         font-weight: normal;
       }
-
-      .dropdown a:hover {background-color: #ddd;}
 
       .show {display: block;}
     </style>
@@ -215,7 +209,7 @@ State1 --> State2 : Ev2
         <div class="history">
             <div class="titlebar">Log
             <div class='dropdown'>
-              <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
+              <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
               <div id='myDropdown' class='dropdown-content'>
                 <div class='dropdown-item'>
                   <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -83,10 +83,11 @@
       }
 
       table.console td.timestamp {
+        display: none;
       }
 
       table.console.timestamps td.timestamp {
-        display: none;
+        display: table-cell;
       }
 
       .console th {
@@ -220,7 +221,7 @@ State1 --> State2 : Ev2
               </div>
             </div>            
             </div>
-            <table class="console timestamps">
+            <table class="console">
             <tbody>
             </tbody>
             </table>

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -829,6 +829,13 @@ evaluateGuard = null;
 
         gutter.addEventListener('mousedown', resizer);
 
+        document.getElementById('timestamps').addEventListener('change', function() {
+          const showTimestamps = this.checked;
+          const timestamps = document.querySelectorAll('.timestamp');
+          for (const timestamp of timestamps) {
+            timestamp.style.display = showTimestamps ? 'table-cell' : 'none';
+          }
+        });
         document.getElementById('dropbtn').addEventListener('click', myFunction);
 
         /* When the user clicks on the button, 

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -121,7 +121,7 @@
       .history {
         margin-top: 30px;       
         display: flex;
-        overflow: scroll;    
+        overflow: auto;    
         flex-direction: column-reverse;
       }
 

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -151,6 +151,7 @@
       .dropdown-content {
         display: none;
         position: absolute;
+        right: 0;
         background-color: #f1f1f1;
         min-width: 160px;
         overflow: auto;

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -146,11 +146,9 @@
         z-index: 1;
       }
 
-      .dropdown-content a {
-        color: black;
+      .dropdown-content .dropdown-item {
         padding: 12px 16px;
-        text-decoration: none;
-        display: block;
+        font-weight: normal;
       }
 
       .dropdown a:hover {background-color: #ddd;}
@@ -208,7 +206,10 @@ State1 --> State2 : Ev2
             <div class='dropdown'>
               <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
               <div id='myDropdown' class='dropdown-content'>
-                <a href='#home'>Display timestamps</a>
+                <div class='dropdown-item'>
+                  <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
+                  <label for=timestamps'>Timestamps</label>
+                </div>
               </div>
             </div>            
             </div>

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -35,7 +35,6 @@
         font-family: 'Material Symbols Outlined', sans-serif;
         font-size: 16px;
         color: #777;
-        margin-left: auto;
         border-radius: 5px;
       }
 
@@ -146,6 +145,7 @@
       .dropdown {
         position: relative;
         display: inline-block;
+        margin-left: auto;
       }
 
       .dropdown-content {

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -12,6 +12,7 @@
   -->
 <html>
   <head>
+    <link rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined'>
     <style>
       body {
         display: flex;
@@ -28,6 +29,13 @@
       .pane {
         padding: 1em;
         min-width: 200px;
+      }
+
+      .titlebar-icon {
+        font-family: 'Material Symbols Outlined', sans-serif;
+        font-size: 16px;
+        color: #777;
+        margin-left: auto;
       }
 
       .gutter {
@@ -65,6 +73,7 @@
         border-bottom: 1px solid #ccc;
         font-weight: bold;
         padding: 5px;
+        display: flex;
       }
 
       .console {
@@ -112,6 +121,41 @@
       button {
         margin: 5px;
       }
+
+      .dropbtn {
+        border: none;
+        cursor: pointer;
+      }
+
+      .dropbtn:hover, .dropbtn:focus {
+        background-color: #2980B9;
+      }
+
+      .dropdown {
+        position: relative;
+        display: inline-block;
+      }
+
+      .dropdown-content {
+        display: none;
+        position: absolute;
+        background-color: #f1f1f1;
+        min-width: 160px;
+        overflow: auto;
+        box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+        z-index: 1;
+      }
+
+      .dropdown-content a {
+        color: black;
+        padding: 12px 16px;
+        text-decoration: none;
+        display: block;
+      }
+
+      .dropdown a:hover {background-color: #ddd;}
+
+      .show {display: block;}
     </style>
   </head>
 
@@ -160,7 +204,14 @@ State1 --> State2 : Ev2
         </div>
 
         <div class="history">
-            <div class="titlebar">Log</div>
+            <div class="titlebar">Log
+            <div class='dropdown'>
+              <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
+              <div id='myDropdown' class='dropdown-content'>
+                <a href='#home'>Display timestamps</a>
+              </div>
+            </div>            
+            </div>
             <table class="console">
             <tbody>
             </tbody>
@@ -776,6 +827,29 @@ evaluateGuard = null;
         }
 
         gutter.addEventListener('mousedown', resizer);
+
+        document.getElementById('dropbtn').addEventListener('click', myFunction);
+
+        /* When the user clicks on the button, 
+        toggle between hiding and showing the dropdown content */
+        function myFunction() {
+          document.getElementById('myDropdown').classList.add('show');
+        }
+
+        // Close the dropdown if the user clicks outside of it
+        window.onclick = function(event) {
+          if (!event.target.matches('.dropbtn')) {
+            var dropdowns = document.getElementsByClassName('dropdown-content');
+            var i;
+            for (i = 0; i < dropdowns.length; i++) {
+              var openDropdown = dropdowns[i];
+              if (openDropdown.classList.contains('show')) {
+                openDropdown.classList.remove('show');
+              }
+            }
+          }
+        }
+
 
 
 

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -129,6 +129,10 @@
         border-bottom: none;
       }
 
+      button {
+        margin: 5px;
+      }
+
       .dropbtn {
         border: none;
         cursor: pointer;

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -99,8 +99,6 @@
       }
 
       .console tbody {
-        display: flex;
-        flex-direction: column-reverse;
         font-family: monospace;
       }
 
@@ -121,8 +119,10 @@
       }
 
       .history {
-        margin-top: 30px;
+        margin-top: 30px;       
+        display: flex;
         overflow: scroll;    
+        flex-direction: column-reverse;
       }
 
       .console tr:last-child td {
@@ -225,8 +225,8 @@ State1 --> State2 : Ev2
             </div>            
             </div>
             <table class="console">
-            <tbody>
-            </tbody>
+              <tbody>
+              </tbody>
             </table>
         </div>
 

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -36,6 +36,7 @@
         font-size: 16px;
         color: #777;
         margin-left: auto;
+        border-radius: 5px;
       }
 
       .gutter {

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -833,7 +833,7 @@ evaluateGuard = null;
         /* When the user clicks on the button, 
         toggle between hiding and showing the dropdown content */
         function myFunction() {
-          document.getElementById('myDropdown').classList.add('show');
+          document.getElementById('myDropdown').classList.toggle('show');
         }
 
         // Close the dropdown if the user clicks outside of it

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -82,6 +82,13 @@
         width: 100%;
       }
 
+      table.console td.timestamp {
+      }
+
+      table.console.timestamps td.timestamp {
+        display: none;
+      }
+
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;
@@ -213,7 +220,7 @@ State1 --> State2 : Ev2
               </div>
             </div>            
             </div>
-            <table class="console">
+            <table class="console timestamps">
             <tbody>
             </tbody>
             </table>
@@ -829,13 +836,15 @@ evaluateGuard = null;
 
         gutter.addEventListener('mousedown', resizer);
 
+        document.getElementById('timestamps').checked = document.querySelector('table.console').classList.contains('timestamps');
         document.getElementById('timestamps').addEventListener('change', function() {
-          const showTimestamps = this.checked;
-          const timestamps = document.querySelectorAll('.timestamp');
-          for (const timestamp of timestamps) {
-            timestamp.style.display = showTimestamps ? 'table-cell' : 'none';
+          if(this.checked) {
+            document.querySelector('table.console').classList.add('timestamps');
+          } else {
+            document.querySelector('table.console').classList.remove('timestamps');
           }
         });
+
         document.getElementById('dropbtn').addEventListener('click', myFunction);
 
         /* When the user clicks on the button, 

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -104,8 +104,11 @@
         font-family: monospace;
       }
 
-      .console td {
+      .console tr {
         border-bottom: 1px solid #ccc;
+      }
+
+      .console td {
         padding: 5px;
       }
   

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -209,25 +209,24 @@ State1 --> State2 : Ev2
 
     <div class="pane sidebar">
         <div id="buttons">
-            <div class="titlebar">Events</div>
+            <div class="titlebar">Events            
+              <div class='dropdown'>
+                <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
+                <div id='myDropdown' class='dropdown-content'>
+                  <div class='dropdown-item'>
+                    <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
+                    <label for=timestamps'>Timestamps</label>
+                  </div>
+                </div>
+              </div>            
+          </div>
         </div>
 
         <div class="history">
-            <div class="titlebar">Log
-            <div class='dropdown'>
-              <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
-              <div id='myDropdown' class='dropdown-content'>
-                <div class='dropdown-item'>
-                  <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
-                  <label for=timestamps'>Timestamps</label>
-                </div>
-              </div>
-            </div>            
-            </div>
-            <table class="console">
-              <tbody>
-              </tbody>
-            </table>
+          <table class="console">
+            <tbody>
+            </tbody>
+          </table>
         </div>
 
         <div class="gutter"></div>

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -216,7 +216,7 @@ State1 --> State2 : Ev2
                 <div id='myDropdown' class='dropdown-content'>
                   <div class='dropdown-item'>
                     <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
-                    <label for=timestamps'>Timestamps</label>
+                    <label for='timestamps'>Timestamps</label>
                   </div>
                 </div>
               </div>            

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -56,6 +56,7 @@
 
       .sidebar {
         width: 300px;
+        padding-top: 0px;
         position: relative;
         background-color: #f0f0f0;
         border-left: 1px solid #ccc;

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -129,17 +129,13 @@
         border-bottom: none;
       }
 
-      button {
-        margin: 5px;
-      }
-
       .dropbtn {
         border: none;
         cursor: pointer;
       }
 
       .dropbtn:hover, .dropbtn:focus {
-        background-color: #2980B9;
+        background-color: #f1f1f1;
       }
 
       .dropdown {
@@ -161,8 +157,6 @@
         padding: 12px 16px;
         font-weight: normal;
       }
-
-      .dropdown a:hover {background-color: #ddd;}
 
       .show {display: block;}
     </style>
@@ -215,7 +209,7 @@ State1 --> State2 : Ev2
         <div class="history">
             <div class="titlebar">Log
             <div class='dropdown'>
-              <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
+              <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
               <div id='myDropdown' class='dropdown-content'>
                 <div class='dropdown-item'>
                   <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -83,10 +83,11 @@
       }
 
       table.console td.timestamp {
+        display: none;
       }
 
       table.console.timestamps td.timestamp {
-        display: none;
+        display: table-cell;
       }
 
       .console th {
@@ -220,7 +221,7 @@ State1 --> State2 : Ev2
               </div>
             </div>            
             </div>
-            <table class="console timestamps">
+            <table class="console">
             <tbody>
             </tbody>
             </table>

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -829,6 +829,13 @@ evaluateGuard = null;
 
         gutter.addEventListener('mousedown', resizer);
 
+        document.getElementById('timestamps').addEventListener('change', function() {
+          const showTimestamps = this.checked;
+          const timestamps = document.querySelectorAll('.timestamp');
+          for (const timestamp of timestamps) {
+            timestamp.style.display = showTimestamps ? 'table-cell' : 'none';
+          }
+        });
         document.getElementById('dropbtn').addEventListener('click', myFunction);
 
         /* When the user clicks on the button, 

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -121,7 +121,7 @@
       .history {
         margin-top: 30px;       
         display: flex;
-        overflow: scroll;    
+        overflow: auto;    
         flex-direction: column-reverse;
       }
 

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -151,6 +151,7 @@
       .dropdown-content {
         display: none;
         position: absolute;
+        right: 0;
         background-color: #f1f1f1;
         min-width: 160px;
         overflow: auto;

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -2550,6 +2550,13 @@ evaluateGuard = null;
 
         gutter.addEventListener('mousedown', resizer);
 
+        document.getElementById('timestamps').addEventListener('change', function() {
+          const showTimestamps = this.checked;
+          const timestamps = document.querySelectorAll('.timestamp');
+          for (const timestamp of timestamps) {
+            timestamp.style.display = showTimestamps ? 'table-cell' : 'none';
+          }
+        });
         document.getElementById('dropbtn').addEventListener('click', myFunction);
 
         /* When the user clicks on the button, 

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -35,7 +35,6 @@
         font-family: 'Material Symbols Outlined', sans-serif;
         font-size: 16px;
         color: #777;
-        margin-left: auto;
         border-radius: 5px;
       }
 
@@ -146,6 +145,7 @@
       .dropdown {
         position: relative;
         display: inline-block;
+        margin-left: auto;
       }
 
       .dropdown-content {

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -83,10 +83,11 @@
       }
 
       table.console td.timestamp {
+        display: none;
       }
 
       table.console.timestamps td.timestamp {
-        display: none;
+        display: table-cell;
       }
 
       .console th {
@@ -316,7 +317,7 @@ MENU.(InitialState) --> MAIN_MENU_INNER
               </div>
             </div>            
             </div>
-            <table class="console timestamps">
+            <table class="console">
             <tbody>
             </tbody>
             </table>

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -82,6 +82,13 @@
         width: 100%;
       }
 
+      table.console td.timestamp {
+      }
+
+      table.console.timestamps td.timestamp {
+        display: none;
+      }
+
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;
@@ -309,7 +316,7 @@ MENU.(InitialState) --> MAIN_MENU_INNER
               </div>
             </div>            
             </div>
-            <table class="console">
+            <table class="console timestamps">
             <tbody>
             </tbody>
             </table>
@@ -2550,13 +2557,15 @@ evaluateGuard = null;
 
         gutter.addEventListener('mousedown', resizer);
 
+        document.getElementById('timestamps').checked = document.querySelector('table.console').classList.contains('timestamps');
         document.getElementById('timestamps').addEventListener('change', function() {
-          const showTimestamps = this.checked;
-          const timestamps = document.querySelectorAll('.timestamp');
-          for (const timestamp of timestamps) {
-            timestamp.style.display = showTimestamps ? 'table-cell' : 'none';
+          if(this.checked) {
+            document.querySelector('table.console').classList.add('timestamps');
+          } else {
+            document.querySelector('table.console').classList.remove('timestamps');
           }
         });
+
         document.getElementById('dropbtn').addEventListener('click', myFunction);
 
         /* When the user clicks on the button, 

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -129,6 +129,10 @@
         border-bottom: none;
       }
 
+      button {
+        margin: 5px;
+      }
+
       .dropbtn {
         border: none;
         cursor: pointer;

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -312,7 +312,7 @@ MENU.(InitialState) --> MAIN_MENU_INNER
                 <div id='myDropdown' class='dropdown-content'>
                   <div class='dropdown-item'>
                     <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
-                    <label for=timestamps'>Timestamps</label>
+                    <label for='timestamps'>Timestamps</label>
                   </div>
                 </div>
               </div>            

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -36,6 +36,7 @@
         font-size: 16px;
         color: #777;
         margin-left: auto;
+        border-radius: 5px;
       }
 
       .gutter {

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -129,17 +129,13 @@
         border-bottom: none;
       }
 
-      button {
-        margin: 5px;
-      }
-
       .dropbtn {
         border: none;
         cursor: pointer;
       }
 
       .dropbtn:hover, .dropbtn:focus {
-        background-color: #2980B9;
+        background-color: #f1f1f1;
       }
 
       .dropdown {
@@ -161,8 +157,6 @@
         padding: 12px 16px;
         font-weight: normal;
       }
-
-      .dropdown a:hover {background-color: #ddd;}
 
       .show {display: block;}
     </style>
@@ -311,7 +305,7 @@ MENU.(InitialState) --> MAIN_MENU_INNER
         <div class="history">
             <div class="titlebar">Log
             <div class='dropdown'>
-              <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
+              <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
               <div id='myDropdown' class='dropdown-content'>
                 <div class='dropdown-item'>
                   <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -104,8 +104,11 @@
         font-family: monospace;
       }
 
-      .console td {
+      .console tr {
         border-bottom: 1px solid #ccc;
+      }
+
+      .console td {
         padding: 5px;
       }
   

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -12,6 +12,7 @@
   -->
 <html>
   <head>
+    <link rel='stylesheet' href='https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined'>
     <style>
       body {
         display: flex;
@@ -28,6 +29,13 @@
       .pane {
         padding: 1em;
         min-width: 200px;
+      }
+
+      .titlebar-icon {
+        font-family: 'Material Symbols Outlined', sans-serif;
+        font-size: 16px;
+        color: #777;
+        margin-left: auto;
       }
 
       .gutter {
@@ -65,6 +73,7 @@
         border-bottom: 1px solid #ccc;
         font-weight: bold;
         padding: 5px;
+        display: flex;
       }
 
       .console {
@@ -112,6 +121,41 @@
       button {
         margin: 5px;
       }
+
+      .dropbtn {
+        border: none;
+        cursor: pointer;
+      }
+
+      .dropbtn:hover, .dropbtn:focus {
+        background-color: #2980B9;
+      }
+
+      .dropdown {
+        position: relative;
+        display: inline-block;
+      }
+
+      .dropdown-content {
+        display: none;
+        position: absolute;
+        background-color: #f1f1f1;
+        min-width: 160px;
+        overflow: auto;
+        box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+        z-index: 1;
+      }
+
+      .dropdown-content a {
+        color: black;
+        padding: 12px 16px;
+        text-decoration: none;
+        display: block;
+      }
+
+      .dropdown a:hover {background-color: #ddd;}
+
+      .show {display: block;}
     </style>
   </head>
 
@@ -256,7 +300,14 @@ MENU.(InitialState) --> MAIN_MENU_INNER
         </div>
 
         <div class="history">
-            <div class="titlebar">Log</div>
+            <div class="titlebar">Log
+            <div class='dropdown'>
+              <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
+              <div id='myDropdown' class='dropdown-content'>
+                <a href='#home'>Display timestamps</a>
+              </div>
+            </div>            
+            </div>
             <table class="console">
             <tbody>
             </tbody>
@@ -2497,6 +2548,29 @@ evaluateGuard = null;
         }
 
         gutter.addEventListener('mousedown', resizer);
+
+        document.getElementById('dropbtn').addEventListener('click', myFunction);
+
+        /* When the user clicks on the button, 
+        toggle between hiding and showing the dropdown content */
+        function myFunction() {
+          document.getElementById('myDropdown').classList.add('show');
+        }
+
+        // Close the dropdown if the user clicks outside of it
+        window.onclick = function(event) {
+          if (!event.target.matches('.dropbtn')) {
+            var dropdowns = document.getElementsByClassName('dropdown-content');
+            var i;
+            for (i = 0; i < dropdowns.length; i++) {
+              var openDropdown = dropdowns[i];
+              if (openDropdown.classList.contains('show')) {
+                openDropdown.classList.remove('show');
+              }
+            }
+          }
+        }
+
 
 
 

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -146,11 +146,9 @@
         z-index: 1;
       }
 
-      .dropdown-content a {
-        color: black;
+      .dropdown-content .dropdown-item {
         padding: 12px 16px;
-        text-decoration: none;
-        display: block;
+        font-weight: normal;
       }
 
       .dropdown a:hover {background-color: #ddd;}
@@ -304,7 +302,10 @@ MENU.(InitialState) --> MAIN_MENU_INNER
             <div class='dropdown'>
               <button id='dropbtn' class='titlebar-icon dropbtn'>settings</button>
               <div id='myDropdown' class='dropdown-content'>
-                <a href='#home'>Display timestamps</a>
+                <div class='dropdown-item'>
+                  <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
+                  <label for=timestamps'>Timestamps</label>
+                </div>
               </div>
             </div>            
             </div>

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -99,8 +99,6 @@
       }
 
       .console tbody {
-        display: flex;
-        flex-direction: column-reverse;
         font-family: monospace;
       }
 
@@ -121,8 +119,10 @@
       }
 
       .history {
-        margin-top: 30px;
+        margin-top: 30px;       
+        display: flex;
         overflow: scroll;    
+        flex-direction: column-reverse;
       }
 
       .console tr:last-child td {
@@ -321,8 +321,8 @@ MENU.(InitialState) --> MAIN_MENU_INNER
             </div>            
             </div>
             <table class="console">
-            <tbody>
-            </tbody>
+              <tbody>
+              </tbody>
             </table>
         </div>
 

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -305,25 +305,24 @@ MENU.(InitialState) --> MAIN_MENU_INNER
 
     <div class="pane sidebar">
         <div id="buttons">
-            <div class="titlebar">Events</div>
+            <div class="titlebar">Events            
+              <div class='dropdown'>
+                <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
+                <div id='myDropdown' class='dropdown-content'>
+                  <div class='dropdown-item'>
+                    <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
+                    <label for=timestamps'>Timestamps</label>
+                  </div>
+                </div>
+              </div>            
+          </div>
         </div>
 
         <div class="history">
-            <div class="titlebar">Log
-            <div class='dropdown'>
-              <span id='dropbtn' class='titlebar-icon dropbtn'>settings</span>
-              <div id='myDropdown' class='dropdown-content'>
-                <div class='dropdown-item'>
-                  <input type='checkbox' id='timestamps' name='timestamps' value='Timestamps'>
-                  <label for=timestamps'>Timestamps</label>
-                </div>
-              </div>
-            </div>            
-            </div>
-            <table class="console">
-              <tbody>
-              </tbody>
-            </table>
+          <table class="console">
+            <tbody>
+            </tbody>
+          </table>
         </div>
 
         <div class="gutter"></div>

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -56,6 +56,7 @@
 
       .sidebar {
         width: 300px;
+        padding-top: 0px;
         position: relative;
         background-color: #f0f0f0;
         border-left: 1px solid #ccc;

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -121,7 +121,7 @@
       .history {
         margin-top: 30px;       
         display: flex;
-        overflow: scroll;    
+        overflow: auto;    
         flex-direction: column-reverse;
       }
 

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -151,6 +151,7 @@
       .dropdown-content {
         display: none;
         position: absolute;
+        right: 0;
         background-color: #f1f1f1;
         min-width: 160px;
         overflow: auto;

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -2554,7 +2554,7 @@ evaluateGuard = null;
         /* When the user clicks on the button, 
         toggle between hiding and showing the dropdown content */
         function myFunction() {
-          document.getElementById('myDropdown').classList.add('show');
+          document.getElementById('myDropdown').classList.toggle('show');
         }
 
         // Close the dropdown if the user clicks outside of it


### PR DESCRIPTION
- add a settings button that lets you enable/disable the timestamps
- order events chronologically instead of reverse-chronologically, closes #289
- non-mac devices should no longer show scrollbars (overflow: auto instead of scroll)

Closes #295