### PR TITLE
Clearly highlight transitions

### DIFF
--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -238,6 +238,11 @@ public class HtmlRenderer
         document.querySelector('svg').setAttribute('height', '100%');
         document.querySelector('svg').style[""max-width""] = '';
 
+        // don't scale the arrow when we scale the transition edge
+        document.querySelectorAll('g defs marker[id$=barbEnd]').forEach(marker => {
+            marker.setAttribute('markerUnits', 'userSpaceOnUse');
+        });
+
         var panZoom = window.panZoom = svgPanZoom(document.querySelector('svg'), {
             zoomEnabled: true,
             controlIconsEnabled: true,

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -187,7 +187,7 @@ public class HtmlRenderer
       .show {display: block;}
 
       .transition.active {
-        stroke: yellow !important;
+        stroke: #fff5ad !important;
         stroke-width: 5px !important;
         filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
       }

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -350,6 +350,7 @@ public class HtmlRenderer
             if (edge) {
                 edge.style.stroke = 'yellow';
                 edge.style.strokeWidth = '5px';
+                edge.style.filter = 'drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7))';
                 highlightedEdges.add(edge);
             }
         }

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -343,7 +343,8 @@ public class HtmlRenderer
         function highlightEdge(edgeId) {
             var edge = document.getElementById(edgeId);
             if (edge) {
-                edge.style.stroke = 'red';
+                edge.style.stroke = 'yellow';
+                edge.style.strokeWidth = '5px';
                 highlightedEdges.add(edge);
             }
         }

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -192,6 +192,11 @@ public class HtmlRenderer
         filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
       }
 
+      .statediagram-state.active > * {
+        fill: #fff5ad !important;
+        stroke-width: 2px !important;
+      }
+
     </style>
   </head>
 

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -185,6 +185,13 @@ public class HtmlRenderer
       }
 
       .show {display: block;}
+
+      .transition.active {
+        stroke: yellow !important;
+        stroke-width: 5px !important;
+        filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
+      }
+
     </style>
   </head>
 
@@ -348,23 +355,19 @@ public class HtmlRenderer
         function highlightEdge(edgeId) {
             var edge = document.getElementById(edgeId);
             if (edge) {
-                edge.style.stroke = 'yellow';
-                edge.style.strokeWidth = '5px';
-                edge.style.filter = 'drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7))';
-                highlightedEdges.add(edge);
+              edge.classList.add('active');
+              highlightedEdges.add(edge);
             }
         }
 
         function clearHighlightedEdges() {
             for (const edge of highlightedEdges) {
-                const showOldTraversal = false;
-                if (showOldTraversal) {
-                    // shows that the edge was traversed. Optional, but kinda nice.
-                    edge.style.stroke = 'green';
-                } else {
-                    edge.style.stroke = '';
-                }
-                edge.style.strokeWidth = '1px';
+              edge.classList.remove('active');
+              const showOldTraversal = false;
+              if (showOldTraversal) {
+                  // shows that the edge was traversed. Optional, but kinda nice.
+                  edge.style.stroke = 'green';
+              }
             }
             highlightedEdges.clear();
         }

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -356,13 +356,14 @@ public class HtmlRenderer
 
         function clearHighlightedEdges() {
             for (const edge of highlightedEdges) {
-                const showOldTraversal = true;
+                const showOldTraversal = false;
                 if (showOldTraversal) {
                     // shows that the edge was traversed. Optional, but kinda nice.
                     edge.style.stroke = 'green';
                 } else {
                     edge.style.stroke = '';
                 }
+                edge.style.strokeWidth = '1px';
             }
             highlightedEdges.clear();
         }

--- a/src/StateSmith/Output/Sim/MermaidGenerator.cs
+++ b/src/StateSmith/Output/Sim/MermaidGenerator.cs
@@ -43,7 +43,7 @@ class MermaidGenerator : IVertexVisitor
     public void Visit(StateMachine v)
     {
         AppendIndentedLine("stateDiagram");
-        AppendIndentedLine("classDef active fill:yellow,stroke-width:2px;");
+        AppendIndentedLine("classDef active fill:#fff5ad,stroke-width:2px;");
         indentLevel--; // don't indent the state machine contents
         VisitChildren(v);
     }

--- a/src/StateSmith/Output/Sim/MermaidGenerator.cs
+++ b/src/StateSmith/Output/Sim/MermaidGenerator.cs
@@ -43,7 +43,6 @@ class MermaidGenerator : IVertexVisitor
     public void Visit(StateMachine v)
     {
         AppendIndentedLine("stateDiagram");
-        AppendIndentedLine("classDef active fill:#fff5ad,stroke-width:2px;");
         indentLevel--; // don't indent the state machine contents
         VisitChildren(v);
     }

--- a/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
@@ -176,7 +176,7 @@
       .show {display: block;}
 
       .transition.active {
-        stroke: yellow !important;
+        stroke: #fff5ad !important;
         stroke-width: 5px !important;
         filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
       }
@@ -190,7 +190,7 @@
         <pre class="mermaid">
 stateDiagram
 
-classDef active fill:yellow,stroke-width:2px;
+classDef active fill:#fff5ad,stroke-width:2px;
 
 state Running {
 

--- a/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
@@ -3148,13 +3148,14 @@ evaluateGuard = null;
 
         function clearHighlightedEdges() {
             for (const edge of highlightedEdges) {
-                const showOldTraversal = true;
+                const showOldTraversal = false;
                 if (showOldTraversal) {
                     // shows that the edge was traversed. Optional, but kinda nice.
                     edge.style.stroke = 'green';
                 } else {
                     edge.style.stroke = '';
                 }
+                edge.style.strokeWidth = '1px';
             }
             highlightedEdges.clear();
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
@@ -3030,6 +3030,11 @@ evaluateGuard = null;
         document.querySelector('svg').setAttribute('height', '100%');
         document.querySelector('svg').style["max-width"] = '';
 
+        // don't scale the arrow when we scale the transition edge
+        document.querySelectorAll('g defs marker[id$=barbEnd]').forEach(marker => {
+            marker.setAttribute('markerUnits', 'userSpaceOnUse');
+        });
+
         var panZoom = window.panZoom = svgPanZoom(document.querySelector('svg'), {
             zoomEnabled: true,
             controlIconsEnabled: true,

--- a/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
@@ -3135,7 +3135,8 @@ evaluateGuard = null;
         function highlightEdge(edgeId) {
             var edge = document.getElementById(edgeId);
             if (edge) {
-                edge.style.stroke = 'red';
+                edge.style.stroke = 'yellow';
+                edge.style.strokeWidth = '5px';
                 highlightedEdges.add(edge);
             }
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
@@ -174,6 +174,13 @@
       }
 
       .show {display: block;}
+
+      .transition.active {
+        stroke: yellow !important;
+        stroke-width: 5px !important;
+        filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
+      }
+
     </style>
   </head>
 
@@ -3140,23 +3147,19 @@ evaluateGuard = null;
         function highlightEdge(edgeId) {
             var edge = document.getElementById(edgeId);
             if (edge) {
-                edge.style.stroke = 'yellow';
-                edge.style.strokeWidth = '5px';
-                edge.style.filter = 'drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7))';
-                highlightedEdges.add(edge);
+              edge.classList.add('active');
+              highlightedEdges.add(edge);
             }
         }
 
         function clearHighlightedEdges() {
             for (const edge of highlightedEdges) {
-                const showOldTraversal = false;
-                if (showOldTraversal) {
-                    // shows that the edge was traversed. Optional, but kinda nice.
-                    edge.style.stroke = 'green';
-                } else {
-                    edge.style.stroke = '';
-                }
-                edge.style.strokeWidth = '1px';
+              edge.classList.remove('active');
+              const showOldTraversal = false;
+              if (showOldTraversal) {
+                  // shows that the edge was traversed. Optional, but kinda nice.
+                  edge.style.stroke = 'green';
+              }
             }
             highlightedEdges.clear();
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
@@ -181,6 +181,11 @@
         filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
       }
 
+      .statediagram-state.active > * {
+        fill: #fff5ad !important;
+        stroke-width: 2px !important;
+      }
+
     </style>
   </head>
 
@@ -189,8 +194,6 @@
     <div class="pane main">
         <pre class="mermaid">
 stateDiagram
-
-classDef active fill:#fff5ad,stroke-width:2px;
 
 state Running {
 

--- a/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
@@ -3142,6 +3142,7 @@ evaluateGuard = null;
             if (edge) {
                 edge.style.stroke = 'yellow';
                 edge.style.strokeWidth = '5px';
+                edge.style.filter = 'drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7))';
                 highlightedEdges.add(edge);
             }
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -174,6 +174,13 @@
       }
 
       .show {display: block;}
+
+      .transition.active {
+        stroke: yellow !important;
+        stroke-width: 5px !important;
+        filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
+      }
+
     </style>
   </head>
 
@@ -913,23 +920,19 @@ evaluateGuard = null;
         function highlightEdge(edgeId) {
             var edge = document.getElementById(edgeId);
             if (edge) {
-                edge.style.stroke = 'yellow';
-                edge.style.strokeWidth = '5px';
-                edge.style.filter = 'drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7))';
-                highlightedEdges.add(edge);
+              edge.classList.add('active');
+              highlightedEdges.add(edge);
             }
         }
 
         function clearHighlightedEdges() {
             for (const edge of highlightedEdges) {
-                const showOldTraversal = false;
-                if (showOldTraversal) {
-                    // shows that the edge was traversed. Optional, but kinda nice.
-                    edge.style.stroke = 'green';
-                } else {
-                    edge.style.stroke = '';
-                }
-                edge.style.strokeWidth = '1px';
+              edge.classList.remove('active');
+              const showOldTraversal = false;
+              if (showOldTraversal) {
+                  // shows that the edge was traversed. Optional, but kinda nice.
+                  edge.style.stroke = 'green';
+              }
             }
             highlightedEdges.clear();
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -908,7 +908,8 @@ evaluateGuard = null;
         function highlightEdge(edgeId) {
             var edge = document.getElementById(edgeId);
             if (edge) {
-                edge.style.stroke = 'red';
+                edge.style.stroke = 'yellow';
+                edge.style.strokeWidth = '5px';
                 highlightedEdges.add(edge);
             }
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -915,6 +915,7 @@ evaluateGuard = null;
             if (edge) {
                 edge.style.stroke = 'yellow';
                 edge.style.strokeWidth = '5px';
+                edge.style.filter = 'drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7))';
                 highlightedEdges.add(edge);
             }
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -803,6 +803,11 @@ evaluateGuard = null;
         document.querySelector('svg').setAttribute('height', '100%');
         document.querySelector('svg').style["max-width"] = '';
 
+        // don't scale the arrow when we scale the transition edge
+        document.querySelectorAll('g defs marker[id$=barbEnd]').forEach(marker => {
+            marker.setAttribute('markerUnits', 'userSpaceOnUse');
+        });
+
         var panZoom = window.panZoom = svgPanZoom(document.querySelector('svg'), {
             zoomEnabled: true,
             controlIconsEnabled: true,

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -176,7 +176,7 @@
       .show {display: block;}
 
       .transition.active {
-        stroke: yellow !important;
+        stroke: #fff5ad !important;
         stroke-width: 5px !important;
         filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
       }
@@ -190,7 +190,7 @@
         <pre class="mermaid">
 stateDiagram
 
-classDef active fill:yellow,stroke-width:2px;
+classDef active fill:#fff5ad,stroke-width:2px;
 
 state ON_GROUP {
 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -921,13 +921,14 @@ evaluateGuard = null;
 
         function clearHighlightedEdges() {
             for (const edge of highlightedEdges) {
-                const showOldTraversal = true;
+                const showOldTraversal = false;
                 if (showOldTraversal) {
                     // shows that the edge was traversed. Optional, but kinda nice.
                     edge.style.stroke = 'green';
                 } else {
                     edge.style.stroke = '';
                 }
+                edge.style.strokeWidth = '1px';
             }
             highlightedEdges.clear();
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -181,6 +181,11 @@
         filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
       }
 
+      .statediagram-state.active > * {
+        fill: #fff5ad !important;
+        stroke-width: 2px !important;
+      }
+
     </style>
   </head>
 
@@ -189,8 +194,6 @@
     <div class="pane main">
         <pre class="mermaid">
 stateDiagram
-
-classDef active fill:#fff5ad,stroke-width:2px;
 
 state ON_GROUP {
 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -174,6 +174,13 @@
       }
 
       .show {display: block;}
+
+      .transition.active {
+        stroke: yellow !important;
+        stroke-width: 5px !important;
+        filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
+      }
+
     </style>
   </head>
 
@@ -1445,23 +1452,19 @@ evaluateGuard = null;
         function highlightEdge(edgeId) {
             var edge = document.getElementById(edgeId);
             if (edge) {
-                edge.style.stroke = 'yellow';
-                edge.style.strokeWidth = '5px';
-                edge.style.filter = 'drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7))';
-                highlightedEdges.add(edge);
+              edge.classList.add('active');
+              highlightedEdges.add(edge);
             }
         }
 
         function clearHighlightedEdges() {
             for (const edge of highlightedEdges) {
-                const showOldTraversal = false;
-                if (showOldTraversal) {
-                    // shows that the edge was traversed. Optional, but kinda nice.
-                    edge.style.stroke = 'green';
-                } else {
-                    edge.style.stroke = '';
-                }
-                edge.style.strokeWidth = '1px';
+              edge.classList.remove('active');
+              const showOldTraversal = false;
+              if (showOldTraversal) {
+                  // shows that the edge was traversed. Optional, but kinda nice.
+                  edge.style.stroke = 'green';
+              }
             }
             highlightedEdges.clear();
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -176,7 +176,7 @@
       .show {display: block;}
 
       .transition.active {
-        stroke: yellow !important;
+        stroke: #fff5ad !important;
         stroke-width: 5px !important;
         filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
       }
@@ -190,7 +190,7 @@
         <pre class="mermaid">
 stateDiagram
 
-classDef active fill:yellow,stroke-width:2px;
+classDef active fill:#fff5ad,stroke-width:2px;
 
 state ORDER_MENU {
 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -181,6 +181,11 @@
         filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
       }
 
+      .statediagram-state.active > * {
+        fill: #fff5ad !important;
+        stroke-width: 2px !important;
+      }
+
     </style>
   </head>
 
@@ -189,8 +194,6 @@
     <div class="pane main">
         <pre class="mermaid">
 stateDiagram
-
-classDef active fill:#fff5ad,stroke-width:2px;
 
 state ORDER_MENU {
 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -1453,13 +1453,14 @@ evaluateGuard = null;
 
         function clearHighlightedEdges() {
             for (const edge of highlightedEdges) {
-                const showOldTraversal = true;
+                const showOldTraversal = false;
                 if (showOldTraversal) {
                     // shows that the edge was traversed. Optional, but kinda nice.
                     edge.style.stroke = 'green';
                 } else {
                     edge.style.stroke = '';
                 }
+                edge.style.strokeWidth = '1px';
             }
             highlightedEdges.clear();
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -1447,6 +1447,7 @@ evaluateGuard = null;
             if (edge) {
                 edge.style.stroke = 'yellow';
                 edge.style.strokeWidth = '5px';
+                edge.style.filter = 'drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7))';
                 highlightedEdges.add(edge);
             }
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -1440,7 +1440,8 @@ evaluateGuard = null;
         function highlightEdge(edgeId) {
             var edge = document.getElementById(edgeId);
             if (edge) {
-                edge.style.stroke = 'red';
+                edge.style.stroke = 'yellow';
+                edge.style.strokeWidth = '5px';
                 highlightedEdges.add(edge);
             }
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -1335,6 +1335,11 @@ evaluateGuard = null;
         document.querySelector('svg').setAttribute('height', '100%');
         document.querySelector('svg').style["max-width"] = '';
 
+        // don't scale the arrow when we scale the transition edge
+        document.querySelectorAll('g defs marker[id$=barbEnd]').forEach(marker => {
+            marker.setAttribute('markerUnits', 'userSpaceOnUse');
+        });
+
         var panZoom = window.panZoom = svgPanZoom(document.querySelector('svg'), {
             zoomEnabled: true,
             controlIconsEnabled: true,

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -843,6 +843,11 @@ evaluateGuard = null;
         document.querySelector('svg').setAttribute('height', '100%');
         document.querySelector('svg').style["max-width"] = '';
 
+        // don't scale the arrow when we scale the transition edge
+        document.querySelectorAll('g defs marker[id$=barbEnd]').forEach(marker => {
+            marker.setAttribute('markerUnits', 'userSpaceOnUse');
+        });
+
         var panZoom = window.panZoom = svgPanZoom(document.querySelector('svg'), {
             zoomEnabled: true,
             controlIconsEnabled: true,

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -961,13 +961,14 @@ evaluateGuard = null;
 
         function clearHighlightedEdges() {
             for (const edge of highlightedEdges) {
-                const showOldTraversal = true;
+                const showOldTraversal = false;
                 if (showOldTraversal) {
                     // shows that the edge was traversed. Optional, but kinda nice.
                     edge.style.stroke = 'green';
                 } else {
                     edge.style.stroke = '';
                 }
+                edge.style.strokeWidth = '1px';
             }
             highlightedEdges.clear();
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -955,6 +955,7 @@ evaluateGuard = null;
             if (edge) {
                 edge.style.stroke = 'yellow';
                 edge.style.strokeWidth = '5px';
+                edge.style.filter = 'drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7))';
                 highlightedEdges.add(edge);
             }
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -181,6 +181,11 @@
         filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
       }
 
+      .statediagram-state.active > * {
+        fill: #fff5ad !important;
+        stroke-width: 2px !important;
+      }
+
     </style>
   </head>
 
@@ -189,8 +194,6 @@
     <div class="pane main">
         <pre class="mermaid">
 stateDiagram
-
-classDef active fill:#fff5ad,stroke-width:2px;
 
 state "$initial_state" as ROOT.(InitialState)
 

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -174,6 +174,13 @@
       }
 
       .show {display: block;}
+
+      .transition.active {
+        stroke: yellow !important;
+        stroke-width: 5px !important;
+        filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
+      }
+
     </style>
   </head>
 
@@ -953,23 +960,19 @@ evaluateGuard = null;
         function highlightEdge(edgeId) {
             var edge = document.getElementById(edgeId);
             if (edge) {
-                edge.style.stroke = 'yellow';
-                edge.style.strokeWidth = '5px';
-                edge.style.filter = 'drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7))';
-                highlightedEdges.add(edge);
+              edge.classList.add('active');
+              highlightedEdges.add(edge);
             }
         }
 
         function clearHighlightedEdges() {
             for (const edge of highlightedEdges) {
-                const showOldTraversal = false;
-                if (showOldTraversal) {
-                    // shows that the edge was traversed. Optional, but kinda nice.
-                    edge.style.stroke = 'green';
-                } else {
-                    edge.style.stroke = '';
-                }
-                edge.style.strokeWidth = '1px';
+              edge.classList.remove('active');
+              const showOldTraversal = false;
+              if (showOldTraversal) {
+                  // shows that the edge was traversed. Optional, but kinda nice.
+                  edge.style.stroke = 'green';
+              }
             }
             highlightedEdges.clear();
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -948,7 +948,8 @@ evaluateGuard = null;
         function highlightEdge(edgeId) {
             var edge = document.getElementById(edgeId);
             if (edge) {
-                edge.style.stroke = 'red';
+                edge.style.stroke = 'yellow';
+                edge.style.strokeWidth = '5px';
                 highlightedEdges.add(edge);
             }
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -176,7 +176,7 @@
       .show {display: block;}
 
       .transition.active {
-        stroke: yellow !important;
+        stroke: #fff5ad !important;
         stroke-width: 5px !important;
         filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
       }
@@ -190,7 +190,7 @@
         <pre class="mermaid">
 stateDiagram
 
-classDef active fill:yellow,stroke-width:2px;
+classDef active fill:#fff5ad,stroke-width:2px;
 
 state "$initial_state" as ROOT.(InitialState)
 

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -843,6 +843,11 @@ evaluateGuard = null;
         document.querySelector('svg').setAttribute('height', '100%');
         document.querySelector('svg').style["max-width"] = '';
 
+        // don't scale the arrow when we scale the transition edge
+        document.querySelectorAll('g defs marker[id$=barbEnd]').forEach(marker => {
+            marker.setAttribute('markerUnits', 'userSpaceOnUse');
+        });
+
         var panZoom = window.panZoom = svgPanZoom(document.querySelector('svg'), {
             zoomEnabled: true,
             controlIconsEnabled: true,

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -961,13 +961,14 @@ evaluateGuard = null;
 
         function clearHighlightedEdges() {
             for (const edge of highlightedEdges) {
-                const showOldTraversal = true;
+                const showOldTraversal = false;
                 if (showOldTraversal) {
                     // shows that the edge was traversed. Optional, but kinda nice.
                     edge.style.stroke = 'green';
                 } else {
                     edge.style.stroke = '';
                 }
+                edge.style.strokeWidth = '1px';
             }
             highlightedEdges.clear();
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -955,6 +955,7 @@ evaluateGuard = null;
             if (edge) {
                 edge.style.stroke = 'yellow';
                 edge.style.strokeWidth = '5px';
+                edge.style.filter = 'drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7))';
                 highlightedEdges.add(edge);
             }
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -181,6 +181,11 @@
         filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
       }
 
+      .statediagram-state.active > * {
+        fill: #fff5ad !important;
+        stroke-width: 2px !important;
+      }
+
     </style>
   </head>
 
@@ -189,8 +194,6 @@
     <div class="pane main">
         <pre class="mermaid">
 stateDiagram
-
-classDef active fill:#fff5ad,stroke-width:2px;
 
 state "$initial_state" as ROOT.(InitialState)
 

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -174,6 +174,13 @@
       }
 
       .show {display: block;}
+
+      .transition.active {
+        stroke: yellow !important;
+        stroke-width: 5px !important;
+        filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
+      }
+
     </style>
   </head>
 
@@ -953,23 +960,19 @@ evaluateGuard = null;
         function highlightEdge(edgeId) {
             var edge = document.getElementById(edgeId);
             if (edge) {
-                edge.style.stroke = 'yellow';
-                edge.style.strokeWidth = '5px';
-                edge.style.filter = 'drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7))';
-                highlightedEdges.add(edge);
+              edge.classList.add('active');
+              highlightedEdges.add(edge);
             }
         }
 
         function clearHighlightedEdges() {
             for (const edge of highlightedEdges) {
-                const showOldTraversal = false;
-                if (showOldTraversal) {
-                    // shows that the edge was traversed. Optional, but kinda nice.
-                    edge.style.stroke = 'green';
-                } else {
-                    edge.style.stroke = '';
-                }
-                edge.style.strokeWidth = '1px';
+              edge.classList.remove('active');
+              const showOldTraversal = false;
+              if (showOldTraversal) {
+                  // shows that the edge was traversed. Optional, but kinda nice.
+                  edge.style.stroke = 'green';
+              }
             }
             highlightedEdges.clear();
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -948,7 +948,8 @@ evaluateGuard = null;
         function highlightEdge(edgeId) {
             var edge = document.getElementById(edgeId);
             if (edge) {
-                edge.style.stroke = 'red';
+                edge.style.stroke = 'yellow';
+                edge.style.strokeWidth = '5px';
                 highlightedEdges.add(edge);
             }
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -176,7 +176,7 @@
       .show {display: block;}
 
       .transition.active {
-        stroke: yellow !important;
+        stroke: #fff5ad !important;
         stroke-width: 5px !important;
         filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
       }
@@ -190,7 +190,7 @@
         <pre class="mermaid">
 stateDiagram
 
-classDef active fill:yellow,stroke-width:2px;
+classDef active fill:#fff5ad,stroke-width:2px;
 
 state "$initial_state" as ROOT.(InitialState)
 

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -2760,6 +2760,7 @@ evaluateGuard = null;
             if (edge) {
                 edge.style.stroke = 'yellow';
                 edge.style.strokeWidth = '5px';
+                edge.style.filter = 'drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7))';
                 highlightedEdges.add(edge);
             }
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -2753,7 +2753,8 @@ evaluateGuard = null;
         function highlightEdge(edgeId) {
             var edge = document.getElementById(edgeId);
             if (edge) {
-                edge.style.stroke = 'red';
+                edge.style.stroke = 'yellow';
+                edge.style.strokeWidth = '5px';
                 highlightedEdges.add(edge);
             }
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -181,6 +181,11 @@
         filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
       }
 
+      .statediagram-state.active > * {
+        fill: #fff5ad !important;
+        stroke-width: 2px !important;
+      }
+
     </style>
   </head>
 
@@ -189,8 +194,6 @@
     <div class="pane main">
         <pre class="mermaid">
 stateDiagram
-
-classDef active fill:#fff5ad,stroke-width:2px;
 
 state "$initial_state" as ROOT.(InitialState)
 

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -2648,6 +2648,11 @@ evaluateGuard = null;
         document.querySelector('svg').setAttribute('height', '100%');
         document.querySelector('svg').style["max-width"] = '';
 
+        // don't scale the arrow when we scale the transition edge
+        document.querySelectorAll('g defs marker[id$=barbEnd]').forEach(marker => {
+            marker.setAttribute('markerUnits', 'userSpaceOnUse');
+        });
+
         var panZoom = window.panZoom = svgPanZoom(document.querySelector('svg'), {
             zoomEnabled: true,
             controlIconsEnabled: true,

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -2766,13 +2766,14 @@ evaluateGuard = null;
 
         function clearHighlightedEdges() {
             for (const edge of highlightedEdges) {
-                const showOldTraversal = true;
+                const showOldTraversal = false;
                 if (showOldTraversal) {
                     // shows that the edge was traversed. Optional, but kinda nice.
                     edge.style.stroke = 'green';
                 } else {
                     edge.style.stroke = '';
                 }
+                edge.style.strokeWidth = '1px';
             }
             highlightedEdges.clear();
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -176,7 +176,7 @@
       .show {display: block;}
 
       .transition.active {
-        stroke: yellow !important;
+        stroke: #fff5ad !important;
         stroke-width: 5px !important;
         filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
       }
@@ -190,7 +190,7 @@
         <pre class="mermaid">
 stateDiagram
 
-classDef active fill:yellow,stroke-width:2px;
+classDef active fill:#fff5ad,stroke-width:2px;
 
 state "$initial_state" as ROOT.(InitialState)
 

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -174,6 +174,13 @@
       }
 
       .show {display: block;}
+
+      .transition.active {
+        stroke: yellow !important;
+        stroke-width: 5px !important;
+        filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
+      }
+
     </style>
   </head>
 
@@ -2758,23 +2765,19 @@ evaluateGuard = null;
         function highlightEdge(edgeId) {
             var edge = document.getElementById(edgeId);
             if (edge) {
-                edge.style.stroke = 'yellow';
-                edge.style.strokeWidth = '5px';
-                edge.style.filter = 'drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7))';
-                highlightedEdges.add(edge);
+              edge.classList.add('active');
+              highlightedEdges.add(edge);
             }
         }
 
         function clearHighlightedEdges() {
             for (const edge of highlightedEdges) {
-                const showOldTraversal = false;
-                if (showOldTraversal) {
-                    // shows that the edge was traversed. Optional, but kinda nice.
-                    edge.style.stroke = 'green';
-                } else {
-                    edge.style.stroke = '';
-                }
-                edge.style.strokeWidth = '1px';
+              edge.classList.remove('active');
+              const showOldTraversal = false;
+              if (showOldTraversal) {
+                  // shows that the edge was traversed. Optional, but kinda nice.
+                  edge.style.stroke = 'green';
+              }
             }
             highlightedEdges.clear();
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
@@ -1065,6 +1065,11 @@ evaluateGuard = null;
         document.querySelector('svg').setAttribute('height', '100%');
         document.querySelector('svg').style["max-width"] = '';
 
+        // don't scale the arrow when we scale the transition edge
+        document.querySelectorAll('g defs marker[id$=barbEnd]').forEach(marker => {
+            marker.setAttribute('markerUnits', 'userSpaceOnUse');
+        });
+
         var panZoom = window.panZoom = svgPanZoom(document.querySelector('svg'), {
             zoomEnabled: true,
             controlIconsEnabled: true,

--- a/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
@@ -1177,6 +1177,7 @@ evaluateGuard = null;
             if (edge) {
                 edge.style.stroke = 'yellow';
                 edge.style.strokeWidth = '5px';
+                edge.style.filter = 'drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7))';
                 highlightedEdges.add(edge);
             }
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
@@ -174,6 +174,13 @@
       }
 
       .show {display: block;}
+
+      .transition.active {
+        stroke: yellow !important;
+        stroke-width: 5px !important;
+        filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
+      }
+
     </style>
   </head>
 
@@ -1175,23 +1182,19 @@ evaluateGuard = null;
         function highlightEdge(edgeId) {
             var edge = document.getElementById(edgeId);
             if (edge) {
-                edge.style.stroke = 'yellow';
-                edge.style.strokeWidth = '5px';
-                edge.style.filter = 'drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7))';
-                highlightedEdges.add(edge);
+              edge.classList.add('active');
+              highlightedEdges.add(edge);
             }
         }
 
         function clearHighlightedEdges() {
             for (const edge of highlightedEdges) {
-                const showOldTraversal = false;
-                if (showOldTraversal) {
-                    // shows that the edge was traversed. Optional, but kinda nice.
-                    edge.style.stroke = 'green';
-                } else {
-                    edge.style.stroke = '';
-                }
-                edge.style.strokeWidth = '1px';
+              edge.classList.remove('active');
+              const showOldTraversal = false;
+              if (showOldTraversal) {
+                  // shows that the edge was traversed. Optional, but kinda nice.
+                  edge.style.stroke = 'green';
+              }
             }
             highlightedEdges.clear();
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
@@ -181,6 +181,11 @@
         filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
       }
 
+      .statediagram-state.active > * {
+        fill: #fff5ad !important;
+        stroke-width: 2px !important;
+      }
+
     </style>
   </head>
 
@@ -189,8 +194,6 @@
     <div class="pane main">
         <pre class="mermaid">
 stateDiagram
-
-classDef active fill:#fff5ad,stroke-width:2px;
 
 state NORMAL {
 

--- a/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
@@ -176,7 +176,7 @@
       .show {display: block;}
 
       .transition.active {
-        stroke: yellow !important;
+        stroke: #fff5ad !important;
         stroke-width: 5px !important;
         filter: drop-shadow( 3px 3px 2px rgba(0, 0, 0, .7));
       }
@@ -190,7 +190,7 @@
         <pre class="mermaid">
 stateDiagram
 
-classDef active fill:yellow,stroke-width:2px;
+classDef active fill:#fff5ad,stroke-width:2px;
 
 state NORMAL {
 

--- a/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
@@ -1183,13 +1183,14 @@ evaluateGuard = null;
 
         function clearHighlightedEdges() {
             for (const edge of highlightedEdges) {
-                const showOldTraversal = true;
+                const showOldTraversal = false;
                 if (showOldTraversal) {
                     // shows that the edge was traversed. Optional, but kinda nice.
                     edge.style.stroke = 'green';
                 } else {
                     edge.style.stroke = '';
                 }
+                edge.style.strokeWidth = '1px';
             }
             highlightedEdges.clear();
         }

--- a/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
@@ -1170,7 +1170,8 @@ evaluateGuard = null;
         function highlightEdge(edgeId) {
             var edge = document.getElementById(edgeId);
             if (edge) {
-                edge.style.stroke = 'red';
+                edge.style.stroke = 'yellow';
+                edge.style.strokeWidth = '5px';
                 highlightedEdges.add(edge);
             }
         }


### PR DESCRIPTION
- active transitions are now yellow to match state highlighting
- active transition width is broader
- disabled highlighting of previously active transitions

<img width="1089" alt="Screenshot 2024-06-07 at 8 07 52 AM" src="https://github.com/StateSmith/StateSmith/assets/310880/7eeff3c8-4b00-48e6-89d8-435984a9c5a8">

Ideally the arrowhead would also be yellow, but i don't know if that's easily doable since the arrowhead is shared between all the transitions.

Closes #320 