### PR TITLE
Improve visual weight of user dispatch actions

### DIFF
--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -108,6 +108,15 @@ public class HtmlRenderer
         display: table-cell;
       }
 
+      table.console td {
+          color: rgba(0, 0, 0, 0.7);
+      }
+
+      table.console td .dispatched {
+          font-weight: bold;
+          color: rgba(0, 0, 0, 1);
+      }
+      
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;
@@ -406,7 +415,7 @@ public class HtmlRenderer
             document.getElementById('buttons').appendChild(button);
         });
 
-        sm.tracer?.log('Start', true);
+        sm.tracer?.log('<span class=""dispatched"">START</span>', true);
         sm.start();
 
 

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -122,7 +122,7 @@ public class HtmlRenderer
       }
 
       table.console tr:has(+tr td .dispatched) td {
-          padding-bottom: 50px;
+          padding-bottom: 25px;
       }
 
       .console th {

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -116,7 +116,15 @@ public class HtmlRenderer
           font-weight: bold;
           color: rgba(0, 0, 0, 1);
       }
-      
+
+      table.console tr:has(+tr td .dispatched) {
+          border-bottom: 0px;
+      }
+
+      table.console tr:has(+tr td .dispatched) td {
+          padding-bottom: 50px;
+      }
+
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;

--- a/src/StateSmith/Output/Sim/HtmlRenderer.cs
+++ b/src/StateSmith/Output/Sim/HtmlRenderer.cs
@@ -132,12 +132,6 @@ public class HtmlRenderer
         font-size: small;
       }
 
-      .console td.emphasis {
-        font-weight: bold;
-        background-color: black;
-        color: white;
-      }
-
       .history {
         margin-top: 30px;       
         display: flex;
@@ -147,6 +141,16 @@ public class HtmlRenderer
 
       .console tr:last-child td {
         border-bottom: none;
+      }
+
+      .dispatched {
+        font-weight: bold;
+      }
+
+      .dispatched > .trigger {
+        border: 1px solid #000;
+        border-radius: 4px;
+        padding: 2px 10px 2px 10px;
       }
 
       button {
@@ -317,16 +321,19 @@ public class HtmlRenderer
         }
 
         // Add a row to the history table.
-        function addHistoryRow(time, event, emphasis = false) {
+        function addHistoryRow(time, event, html = false) {
             var row = document.createElement('tr');
             var timeCell = document.createElement('td');
             timeCell.innerText = formatTime(time);
             timeCell.classList.add('timestamp');
             var eventCell = document.createElement('td');
-            eventCell.innerText = event;
-            if(emphasis) {
-                eventCell.classList.add('emphasis');                
+
+            if(html) {
+              eventCell.innerHTML = event;
+            } else {
+              eventCell.innerText = event;
             }
+
             row.appendChild(timeCell);
             row.appendChild(eventCell);
             document.querySelector('tbody').appendChild(row);
@@ -380,8 +387,8 @@ public class HtmlRenderer
             edgeTransition: (edgeId) => {
                 highlightEdge(edgeId);
             },
-            log: (message, emphasis=false) => {
-                addHistoryRow(new Date(), message, emphasis);
+            log: (message, html=false) => {
+                addHistoryRow(new Date(), message, html);
             }
         };
 
@@ -392,7 +399,7 @@ public class HtmlRenderer
             button.innerText = diagramEventName;
             button.addEventListener('click', () => {
                 clearHighlightedEdges();
-                sm.tracer?.log(""Dispatched "" + diagramEventName, true);
+                sm.tracer?.log('<span class=""dispatched""><span class=""trigger"">' + diagramEventName + '</span> DISPATCHED</span>', true);
                 const fsmEventName = diagramEventName.toUpperCase();
                 sm.dispatchEvent({{smName}}.EventId[fsmEventName]); 
             });

--- a/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
@@ -97,6 +97,15 @@
         display: table-cell;
       }
 
+      table.console td {
+          color: rgba(0, 0, 0, 0.7);
+      }
+
+      table.console td .dispatched {
+          font-weight: bold;
+          color: rgba(0, 0, 0, 1);
+      }
+      
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;
@@ -3198,7 +3207,7 @@ evaluateGuard = null;
             document.getElementById('buttons').appendChild(button);
         });
 
-        sm.tracer?.log('Start', true);
+        sm.tracer?.log('<span class="dispatched">START</span>', true);
         sm.start();
 
 

--- a/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
@@ -111,7 +111,7 @@
       }
 
       table.console tr:has(+tr td .dispatched) td {
-          padding-bottom: 50px;
+          padding-bottom: 25px;
       }
 
       .console th {

--- a/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
@@ -105,7 +105,15 @@
           font-weight: bold;
           color: rgba(0, 0, 0, 1);
       }
-      
+
+      table.console tr:has(+tr td .dispatched) {
+          border-bottom: 0px;
+      }
+
+      table.console tr:has(+tr td .dispatched) td {
+          padding-bottom: 50px;
+      }
+
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;

--- a/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/BeadSorter.sim.html
@@ -121,12 +121,6 @@
         font-size: small;
       }
 
-      .console td.emphasis {
-        font-weight: bold;
-        background-color: black;
-        color: white;
-      }
-
       .history {
         margin-top: 30px;       
         display: flex;
@@ -136,6 +130,16 @@
 
       .console tr:last-child td {
         border-bottom: none;
+      }
+
+      .dispatched {
+        font-weight: bold;
+      }
+
+      .dispatched > .trigger {
+        border: 1px solid #000;
+        border-radius: 4px;
+        padding: 2px 10px 2px 10px;
       }
 
       button {
@@ -3109,16 +3113,19 @@ evaluateGuard = null;
         }
 
         // Add a row to the history table.
-        function addHistoryRow(time, event, emphasis = false) {
+        function addHistoryRow(time, event, html = false) {
             var row = document.createElement('tr');
             var timeCell = document.createElement('td');
             timeCell.innerText = formatTime(time);
             timeCell.classList.add('timestamp');
             var eventCell = document.createElement('td');
-            eventCell.innerText = event;
-            if(emphasis) {
-                eventCell.classList.add('emphasis');                
+
+            if(html) {
+              eventCell.innerHTML = event;
+            } else {
+              eventCell.innerText = event;
             }
+
             row.appendChild(timeCell);
             row.appendChild(eventCell);
             document.querySelector('tbody').appendChild(row);
@@ -3172,8 +3179,8 @@ evaluateGuard = null;
             edgeTransition: (edgeId) => {
                 highlightEdge(edgeId);
             },
-            log: (message, emphasis=false) => {
-                addHistoryRow(new Date(), message, emphasis);
+            log: (message, html=false) => {
+                addHistoryRow(new Date(), message, html);
             }
         };
 
@@ -3184,7 +3191,7 @@ evaluateGuard = null;
             button.innerText = diagramEventName;
             button.addEventListener('click', () => {
                 clearHighlightedEdges();
-                sm.tracer?.log("Dispatched " + diagramEventName, true);
+                sm.tracer?.log('<span class="dispatched"><span class="trigger">' + diagramEventName + '</span> DISPATCHED</span>', true);
                 const fsmEventName = diagramEventName.toUpperCase();
                 sm.dispatchEvent(BeadSorter.EventId[fsmEventName]); 
             });

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -121,12 +121,6 @@
         font-size: small;
       }
 
-      .console td.emphasis {
-        font-weight: bold;
-        background-color: black;
-        color: white;
-      }
-
       .history {
         margin-top: 30px;       
         display: flex;
@@ -136,6 +130,16 @@
 
       .console tr:last-child td {
         border-bottom: none;
+      }
+
+      .dispatched {
+        font-weight: bold;
+      }
+
+      .dispatched > .trigger {
+        border: 1px solid #000;
+        border-radius: 4px;
+        padding: 2px 10px 2px 10px;
       }
 
       button {
@@ -882,16 +886,19 @@ evaluateGuard = null;
         }
 
         // Add a row to the history table.
-        function addHistoryRow(time, event, emphasis = false) {
+        function addHistoryRow(time, event, html = false) {
             var row = document.createElement('tr');
             var timeCell = document.createElement('td');
             timeCell.innerText = formatTime(time);
             timeCell.classList.add('timestamp');
             var eventCell = document.createElement('td');
-            eventCell.innerText = event;
-            if(emphasis) {
-                eventCell.classList.add('emphasis');                
+
+            if(html) {
+              eventCell.innerHTML = event;
+            } else {
+              eventCell.innerText = event;
             }
+
             row.appendChild(timeCell);
             row.appendChild(eventCell);
             document.querySelector('tbody').appendChild(row);
@@ -945,8 +952,8 @@ evaluateGuard = null;
             edgeTransition: (edgeId) => {
                 highlightEdge(edgeId);
             },
-            log: (message, emphasis=false) => {
-                addHistoryRow(new Date(), message, emphasis);
+            log: (message, html=false) => {
+                addHistoryRow(new Date(), message, html);
             }
         };
 
@@ -957,7 +964,7 @@ evaluateGuard = null;
             button.innerText = diagramEventName;
             button.addEventListener('click', () => {
                 clearHighlightedEdges();
-                sm.tracer?.log("Dispatched " + diagramEventName, true);
+                sm.tracer?.log('<span class="dispatched"><span class="trigger">' + diagramEventName + '</span> DISPATCHED</span>', true);
                 const fsmEventName = diagramEventName.toUpperCase();
                 sm.dispatchEvent(LightSm.EventId[fsmEventName]); 
             });

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -111,7 +111,7 @@
       }
 
       table.console tr:has(+tr td .dispatched) td {
-          padding-bottom: 50px;
+          padding-bottom: 25px;
       }
 
       .console th {

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -97,6 +97,15 @@
         display: table-cell;
       }
 
+      table.console td {
+          color: rgba(0, 0, 0, 0.7);
+      }
+
+      table.console td .dispatched {
+          font-weight: bold;
+          color: rgba(0, 0, 0, 1);
+      }
+      
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;
@@ -971,7 +980,7 @@ evaluateGuard = null;
             document.getElementById('buttons').appendChild(button);
         });
 
-        sm.tracer?.log('Start', true);
+        sm.tracer?.log('<span class="dispatched">START</span>', true);
         sm.start();
 
 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm.sim.html
@@ -105,7 +105,15 @@
           font-weight: bold;
           color: rgba(0, 0, 0, 1);
       }
-      
+
+      table.console tr:has(+tr td .dispatched) {
+          border-bottom: 0px;
+      }
+
+      table.console tr:has(+tr td .dispatched) td {
+          padding-bottom: 50px;
+      }
+
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -97,6 +97,15 @@
         display: table-cell;
       }
 
+      table.console td {
+          color: rgba(0, 0, 0, 0.7);
+      }
+
+      table.console td .dispatched {
+          font-weight: bold;
+          color: rgba(0, 0, 0, 1);
+      }
+      
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;
@@ -1503,7 +1512,7 @@ evaluateGuard = null;
             document.getElementById('buttons').appendChild(button);
         });
 
-        sm.tracer?.log('Start', true);
+        sm.tracer?.log('<span class="dispatched">START</span>', true);
         sm.start();
 
 

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -121,12 +121,6 @@
         font-size: small;
       }
 
-      .console td.emphasis {
-        font-weight: bold;
-        background-color: black;
-        color: white;
-      }
-
       .history {
         margin-top: 30px;       
         display: flex;
@@ -136,6 +130,16 @@
 
       .console tr:last-child td {
         border-bottom: none;
+      }
+
+      .dispatched {
+        font-weight: bold;
+      }
+
+      .dispatched > .trigger {
+        border: 1px solid #000;
+        border-radius: 4px;
+        padding: 2px 10px 2px 10px;
       }
 
       button {
@@ -1414,16 +1418,19 @@ evaluateGuard = null;
         }
 
         // Add a row to the history table.
-        function addHistoryRow(time, event, emphasis = false) {
+        function addHistoryRow(time, event, html = false) {
             var row = document.createElement('tr');
             var timeCell = document.createElement('td');
             timeCell.innerText = formatTime(time);
             timeCell.classList.add('timestamp');
             var eventCell = document.createElement('td');
-            eventCell.innerText = event;
-            if(emphasis) {
-                eventCell.classList.add('emphasis');                
+
+            if(html) {
+              eventCell.innerHTML = event;
+            } else {
+              eventCell.innerText = event;
             }
+
             row.appendChild(timeCell);
             row.appendChild(eventCell);
             document.querySelector('tbody').appendChild(row);
@@ -1477,8 +1484,8 @@ evaluateGuard = null;
             edgeTransition: (edgeId) => {
                 highlightEdge(edgeId);
             },
-            log: (message, emphasis=false) => {
-                addHistoryRow(new Date(), message, emphasis);
+            log: (message, html=false) => {
+                addHistoryRow(new Date(), message, html);
             }
         };
 
@@ -1489,7 +1496,7 @@ evaluateGuard = null;
             button.innerText = diagramEventName;
             button.addEventListener('click', () => {
                 clearHighlightedEdges();
-                sm.tracer?.log("Dispatched " + diagramEventName, true);
+                sm.tracer?.log('<span class="dispatched"><span class="trigger">' + diagramEventName + '</span> DISPATCHED</span>', true);
                 const fsmEventName = diagramEventName.toUpperCase();
                 sm.dispatchEvent(LightSm2.EventId[fsmEventName]); 
             });

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -111,7 +111,7 @@
       }
 
       table.console tr:has(+tr td .dispatched) td {
-          padding-bottom: 50px;
+          padding-bottom: 25px;
       }
 
       .console th {

--- a/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/LightSm2.sim.html
@@ -105,7 +105,15 @@
           font-weight: bold;
           color: rgba(0, 0, 0, 1);
       }
-      
+
+      table.console tr:has(+tr td .dispatched) {
+          border-bottom: 0px;
+      }
+
+      table.console tr:has(+tr td .dispatched) td {
+          padding-bottom: 50px;
+      }
+
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -121,12 +121,6 @@
         font-size: small;
       }
 
-      .console td.emphasis {
-        font-weight: bold;
-        background-color: black;
-        color: white;
-      }
-
       .history {
         margin-top: 30px;       
         display: flex;
@@ -136,6 +130,16 @@
 
       .console tr:last-child td {
         border-bottom: none;
+      }
+
+      .dispatched {
+        font-weight: bold;
+      }
+
+      .dispatched > .trigger {
+        border: 1px solid #000;
+        border-radius: 4px;
+        padding: 2px 10px 2px 10px;
       }
 
       button {
@@ -922,16 +926,19 @@ evaluateGuard = null;
         }
 
         // Add a row to the history table.
-        function addHistoryRow(time, event, emphasis = false) {
+        function addHistoryRow(time, event, html = false) {
             var row = document.createElement('tr');
             var timeCell = document.createElement('td');
             timeCell.innerText = formatTime(time);
             timeCell.classList.add('timestamp');
             var eventCell = document.createElement('td');
-            eventCell.innerText = event;
-            if(emphasis) {
-                eventCell.classList.add('emphasis');                
+
+            if(html) {
+              eventCell.innerHTML = event;
+            } else {
+              eventCell.innerText = event;
             }
+
             row.appendChild(timeCell);
             row.appendChild(eventCell);
             document.querySelector('tbody').appendChild(row);
@@ -985,8 +992,8 @@ evaluateGuard = null;
             edgeTransition: (edgeId) => {
                 highlightEdge(edgeId);
             },
-            log: (message, emphasis=false) => {
-                addHistoryRow(new Date(), message, emphasis);
+            log: (message, html=false) => {
+                addHistoryRow(new Date(), message, html);
             }
         };
 
@@ -997,7 +1004,7 @@ evaluateGuard = null;
             button.innerText = diagramEventName;
             button.addEventListener('click', () => {
                 clearHighlightedEdges();
-                sm.tracer?.log("Dispatched " + diagramEventName, true);
+                sm.tracer?.log('<span class="dispatched"><span class="trigger">' + diagramEventName + '</span> DISPATCHED</span>', true);
                 const fsmEventName = diagramEventName.toUpperCase();
                 sm.dispatchEvent(PlantEx1.EventId[fsmEventName]); 
             });

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -111,7 +111,7 @@
       }
 
       table.console tr:has(+tr td .dispatched) td {
-          padding-bottom: 50px;
+          padding-bottom: 25px;
       }
 
       .console th {

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -105,7 +105,15 @@
           font-weight: bold;
           color: rgba(0, 0, 0, 1);
       }
-      
+
+      table.console tr:has(+tr td .dispatched) {
+          border-bottom: 0px;
+      }
+
+      table.console tr:has(+tr td .dispatched) td {
+          padding-bottom: 50px;
+      }
+
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx1.sim.html
@@ -97,6 +97,15 @@
         display: table-cell;
       }
 
+      table.console td {
+          color: rgba(0, 0, 0, 0.7);
+      }
+
+      table.console td .dispatched {
+          font-weight: bold;
+          color: rgba(0, 0, 0, 1);
+      }
+      
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;
@@ -1011,7 +1020,7 @@ evaluateGuard = null;
             document.getElementById('buttons').appendChild(button);
         });
 
-        sm.tracer?.log('Start', true);
+        sm.tracer?.log('<span class="dispatched">START</span>', true);
         sm.start();
 
 

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -111,7 +111,7 @@
       }
 
       table.console tr:has(+tr td .dispatched) td {
-          padding-bottom: 50px;
+          padding-bottom: 25px;
       }
 
       .console th {

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -105,7 +105,15 @@
           font-weight: bold;
           color: rgba(0, 0, 0, 1);
       }
-      
+
+      table.console tr:has(+tr td .dispatched) {
+          border-bottom: 0px;
+      }
+
+      table.console tr:has(+tr td .dispatched) td {
+          padding-bottom: 50px;
+      }
+
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -97,6 +97,15 @@
         display: table-cell;
       }
 
+      table.console td {
+          color: rgba(0, 0, 0, 0.7);
+      }
+
+      table.console td .dispatched {
+          font-weight: bold;
+          color: rgba(0, 0, 0, 1);
+      }
+      
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;
@@ -1011,7 +1020,7 @@ evaluateGuard = null;
             document.getElementById('buttons').appendChild(button);
         });
 
-        sm.tracer?.log('Start', true);
+        sm.tracer?.log('<span class="dispatched">START</span>', true);
         sm.start();
 
 

--- a/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/PlantEx2.sim.html
@@ -121,12 +121,6 @@
         font-size: small;
       }
 
-      .console td.emphasis {
-        font-weight: bold;
-        background-color: black;
-        color: white;
-      }
-
       .history {
         margin-top: 30px;       
         display: flex;
@@ -136,6 +130,16 @@
 
       .console tr:last-child td {
         border-bottom: none;
+      }
+
+      .dispatched {
+        font-weight: bold;
+      }
+
+      .dispatched > .trigger {
+        border: 1px solid #000;
+        border-radius: 4px;
+        padding: 2px 10px 2px 10px;
       }
 
       button {
@@ -922,16 +926,19 @@ evaluateGuard = null;
         }
 
         // Add a row to the history table.
-        function addHistoryRow(time, event, emphasis = false) {
+        function addHistoryRow(time, event, html = false) {
             var row = document.createElement('tr');
             var timeCell = document.createElement('td');
             timeCell.innerText = formatTime(time);
             timeCell.classList.add('timestamp');
             var eventCell = document.createElement('td');
-            eventCell.innerText = event;
-            if(emphasis) {
-                eventCell.classList.add('emphasis');                
+
+            if(html) {
+              eventCell.innerHTML = event;
+            } else {
+              eventCell.innerText = event;
             }
+
             row.appendChild(timeCell);
             row.appendChild(eventCell);
             document.querySelector('tbody').appendChild(row);
@@ -985,8 +992,8 @@ evaluateGuard = null;
             edgeTransition: (edgeId) => {
                 highlightEdge(edgeId);
             },
-            log: (message, emphasis=false) => {
-                addHistoryRow(new Date(), message, emphasis);
+            log: (message, html=false) => {
+                addHistoryRow(new Date(), message, html);
             }
         };
 
@@ -997,7 +1004,7 @@ evaluateGuard = null;
             button.innerText = diagramEventName;
             button.addEventListener('click', () => {
                 clearHighlightedEdges();
-                sm.tracer?.log("Dispatched " + diagramEventName, true);
+                sm.tracer?.log('<span class="dispatched"><span class="trigger">' + diagramEventName + '</span> DISPATCHED</span>', true);
                 const fsmEventName = diagramEventName.toUpperCase();
                 sm.dispatchEvent(PlantEx2.EventId[fsmEventName]); 
             });

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -111,7 +111,7 @@
       }
 
       table.console tr:has(+tr td .dispatched) td {
-          padding-bottom: 50px;
+          padding-bottom: 25px;
       }
 
       .console th {

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -121,12 +121,6 @@
         font-size: small;
       }
 
-      .console td.emphasis {
-        font-weight: bold;
-        background-color: black;
-        color: white;
-      }
-
       .history {
         margin-top: 30px;       
         display: flex;
@@ -136,6 +130,16 @@
 
       .console tr:last-child td {
         border-bottom: none;
+      }
+
+      .dispatched {
+        font-weight: bold;
+      }
+
+      .dispatched > .trigger {
+        border: 1px solid #000;
+        border-radius: 4px;
+        padding: 2px 10px 2px 10px;
       }
 
       button {
@@ -2727,16 +2731,19 @@ evaluateGuard = null;
         }
 
         // Add a row to the history table.
-        function addHistoryRow(time, event, emphasis = false) {
+        function addHistoryRow(time, event, html = false) {
             var row = document.createElement('tr');
             var timeCell = document.createElement('td');
             timeCell.innerText = formatTime(time);
             timeCell.classList.add('timestamp');
             var eventCell = document.createElement('td');
-            eventCell.innerText = event;
-            if(emphasis) {
-                eventCell.classList.add('emphasis');                
+
+            if(html) {
+              eventCell.innerHTML = event;
+            } else {
+              eventCell.innerText = event;
             }
+
             row.appendChild(timeCell);
             row.appendChild(eventCell);
             document.querySelector('tbody').appendChild(row);
@@ -2790,8 +2797,8 @@ evaluateGuard = null;
             edgeTransition: (edgeId) => {
                 highlightEdge(edgeId);
             },
-            log: (message, emphasis=false) => {
-                addHistoryRow(new Date(), message, emphasis);
+            log: (message, html=false) => {
+                addHistoryRow(new Date(), message, html);
             }
         };
 
@@ -2802,7 +2809,7 @@ evaluateGuard = null;
             button.innerText = diagramEventName;
             button.addEventListener('click', () => {
                 clearHighlightedEdges();
-                sm.tracer?.log("Dispatched " + diagramEventName, true);
+                sm.tracer?.log('<span class="dispatched"><span class="trigger">' + diagramEventName + '</span> DISPATCHED</span>', true);
                 const fsmEventName = diagramEventName.toUpperCase();
                 sm.dispatchEvent(SpaceControlUiSm.EventId[fsmEventName]); 
             });

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -97,6 +97,15 @@
         display: table-cell;
       }
 
+      table.console td {
+          color: rgba(0, 0, 0, 0.7);
+      }
+
+      table.console td .dispatched {
+          font-weight: bold;
+          color: rgba(0, 0, 0, 1);
+      }
+      
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;
@@ -2816,7 +2825,7 @@ evaluateGuard = null;
             document.getElementById('buttons').appendChild(button);
         });
 
-        sm.tracer?.log('Start', true);
+        sm.tracer?.log('<span class="dispatched">START</span>', true);
         sm.start();
 
 

--- a/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/SpaceControlUiSm.sim.html
@@ -105,7 +105,15 @@
           font-weight: bold;
           color: rgba(0, 0, 0, 1);
       }
-      
+
+      table.console tr:has(+tr td .dispatched) {
+          border-bottom: 0px;
+      }
+
+      table.console tr:has(+tr td .dispatched) td {
+          padding-bottom: 50px;
+      }
+
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;

--- a/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
@@ -97,6 +97,15 @@
         display: table-cell;
       }
 
+      table.console td {
+          color: rgba(0, 0, 0, 0.7);
+      }
+
+      table.console td .dispatched {
+          font-weight: bold;
+          color: rgba(0, 0, 0, 1);
+      }
+      
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;
@@ -1233,7 +1242,7 @@ evaluateGuard = null;
             document.getElementById('buttons').appendChild(button);
         });
 
-        sm.tracer?.log('Start', true);
+        sm.tracer?.log('<span class="dispatched">START</span>', true);
         sm.start();
 
 

--- a/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
@@ -121,12 +121,6 @@
         font-size: small;
       }
 
-      .console td.emphasis {
-        font-weight: bold;
-        background-color: black;
-        color: white;
-      }
-
       .history {
         margin-top: 30px;       
         display: flex;
@@ -136,6 +130,16 @@
 
       .console tr:last-child td {
         border-bottom: none;
+      }
+
+      .dispatched {
+        font-weight: bold;
+      }
+
+      .dispatched > .trigger {
+        border: 1px solid #000;
+        border-radius: 4px;
+        padding: 2px 10px 2px 10px;
       }
 
       button {
@@ -1144,16 +1148,19 @@ evaluateGuard = null;
         }
 
         // Add a row to the history table.
-        function addHistoryRow(time, event, emphasis = false) {
+        function addHistoryRow(time, event, html = false) {
             var row = document.createElement('tr');
             var timeCell = document.createElement('td');
             timeCell.innerText = formatTime(time);
             timeCell.classList.add('timestamp');
             var eventCell = document.createElement('td');
-            eventCell.innerText = event;
-            if(emphasis) {
-                eventCell.classList.add('emphasis');                
+
+            if(html) {
+              eventCell.innerHTML = event;
+            } else {
+              eventCell.innerText = event;
             }
+
             row.appendChild(timeCell);
             row.appendChild(eventCell);
             document.querySelector('tbody').appendChild(row);
@@ -1207,8 +1214,8 @@ evaluateGuard = null;
             edgeTransition: (edgeId) => {
                 highlightEdge(edgeId);
             },
-            log: (message, emphasis=false) => {
-                addHistoryRow(new Date(), message, emphasis);
+            log: (message, html=false) => {
+                addHistoryRow(new Date(), message, html);
             }
         };
 
@@ -1219,7 +1226,7 @@ evaluateGuard = null;
             button.innerText = diagramEventName;
             button.addEventListener('click', () => {
                 clearHighlightedEdges();
-                sm.tracer?.log("Dispatched " + diagramEventName, true);
+                sm.tracer?.log('<span class="dispatched"><span class="trigger">' + diagramEventName + '</span> DISPATCHED</span>', true);
                 const fsmEventName = diagramEventName.toUpperCase();
                 sm.dispatchEvent(TriggerMap.EventId[fsmEventName]); 
             });

--- a/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
@@ -111,7 +111,7 @@
       }
 
       table.console tr:has(+tr td .dispatched) td {
-          padding-bottom: 50px;
+          padding-bottom: 25px;
       }
 
       .console th {

--- a/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
+++ b/src/StateSmithTest/Output/Sim/diagrams/TriggerMap.sim.html
@@ -105,7 +105,15 @@
           font-weight: bold;
           color: rgba(0, 0, 0, 1);
       }
-      
+
+      table.console tr:has(+tr td .dispatched) {
+          border-bottom: 0px;
+      }
+
+      table.console tr:has(+tr td .dispatched) td {
+          padding-bottom: 50px;
+      }
+
       .console th {
         background-color: #f0f0f0;
         border-bottom: 1px solid #ccc;


### PR DESCRIPTION

<img width="316" alt="Screenshot 2024-06-08 at 10 27 11 AM" src="https://github.com/StateSmith/StateSmith/assets/310880/cbd7863c-164e-40e6-a504-bec08d157bd0">

- style the name of the trigger similar to a button to make it distinctive and suggestion relationship with the trigger buttons up top
- bold and uppercase the text
- reduce the opacity of the non-dispatch events
- add space between the dispatch even and the previous events in the history, and remove the associated border

Closes #314