### PR TITLE
Add ability to watch diagram and csx files for changes

### DIFF
--- a/src/StateSmith.Cli/Run/RunHandler.cs
+++ b/src/StateSmith.Cli/Run/RunHandler.cs
@@ -7,6 +7,7 @@ using StateSmith.Runner;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace StateSmith.Cli.Run;
 
@@ -99,10 +100,9 @@ public class RunHandler
         ReadPastRunInfoDatabase();
         var scanResults = Finder.Scan(searchDirectory: searchDirectory);
 
-        // TODO csxfiles
         // TODO if w flag specified
         var watchers = new List<FileSystemWatcher>();
-        foreach (var diagramFile in scanResults.targetDiagramFiles)
+        foreach (var diagramFile in scanResults.targetDiagramFiles.Union( scanResults.targetCsxFiles ))
         {
             var watcher = new FileSystemWatcher();
             watchers.Add(watcher); // don't let watchers go out of scope yet

--- a/src/StateSmith.Cli/Run/RunHandler.cs
+++ b/src/StateSmith.Cli/Run/RunHandler.cs
@@ -100,31 +100,32 @@ public class RunHandler
         ReadPastRunInfoDatabase();
         var scanResults = Finder.Scan(searchDirectory: searchDirectory);
 
-        // TODO if w flag specified
-        var watchers = new List<FileSystemWatcher>();
-        foreach (var diagramFile in scanResults.targetDiagramFiles.Union( scanResults.targetCsxFiles ))
-        {
-            var watcher = new FileSystemWatcher();
-            watchers.Add(watcher); // don't let watchers go out of scope yet
-            var path = Path.GetDirectoryName(diagramFile);
-            watcher.Path = path!=null && path.Length>0 ? path : "."; 
-            watcher.Filter = Path.GetFileName(diagramFile);
-            _runConsole.WriteLine($"Watching {diagramFile}");
-            _runConsole.WriteLine($"Path: {watcher.Path}");
-            _runConsole.WriteLine($"Filter: {watcher.Filter}");
-            watcher.Changed += (sender, e) => 
-            {
-                _runConsole.WriteLine($"File {diagramFile} has changed.");
-                // TODO only process the changed file. Not sure how to break up ScanResults to do this
-                RunInnerInner(searchDirectory, scanResults);
-            };
-            watcher.EnableRaisingEvents = true;            
-        }
-
         RunInnerInner(searchDirectory, scanResults);
 
-        Console.WriteLine("Watching for changes. Press enter to exit.");
-        Console.ReadLine();
+        if( _runHandlerOptions.Watch) {
+            var watchers = new List<FileSystemWatcher>();
+            foreach (var diagramFile in scanResults.targetDiagramFiles.Union( scanResults.targetCsxFiles ))
+            {
+                var watcher = new FileSystemWatcher();
+                watchers.Add(watcher); // don't let watchers go out of scope yet
+                var path = Path.GetDirectoryName(diagramFile);
+                watcher.Path = path!=null && path.Length>0 ? path : "."; 
+                watcher.Filter = Path.GetFileName(diagramFile);
+                _runConsole.WriteLine($"Watching {diagramFile}");
+                _runConsole.WriteLine($"Path: {watcher.Path}");
+                _runConsole.WriteLine($"Filter: {watcher.Filter}");
+                watcher.Changed += (sender, e) => 
+                {
+                    _runConsole.WriteLine($"File {diagramFile} has changed.");
+                    // TODO only process the changed file. Not sure how to break up ScanResults to do this
+                    RunInnerInner(searchDirectory, scanResults);
+                };
+                watcher.EnableRaisingEvents = true;            
+            }
+
+            Console.WriteLine("Watching for changes. Press enter to exit.");
+            Console.ReadLine();
+        }
     }
 
     private void RunInnerInner(string searchDirectory, SsCsxDiagramFileFinder.ScanResults scanResults) 

--- a/src/StateSmith.Cli/Run/RunHandler.cs
+++ b/src/StateSmith.Cli/Run/RunHandler.cs
@@ -115,7 +115,7 @@ public class RunHandler
             watcher.Changed += (sender, e) => 
             {
                 _runConsole.WriteLine($"File {diagramFile} has changed.");
-                // TODO only process the changed file
+                // TODO only process the changed file. Not sure how to break up ScanResults to do this
                 RunInnerInner(searchDirectory, scanResults);
             };
             watcher.EnableRaisingEvents = true;            

--- a/src/StateSmith.Cli/Run/RunHandler.cs
+++ b/src/StateSmith.Cli/Run/RunHandler.cs
@@ -136,7 +136,6 @@ public class RunHandler
         diagramRunner.Run(scanResults.targetDiagramFiles);
 
         PrintScanInfo(scanResults);
-
     }
 
     private void PrintScanInfo(SsCsxDiagramFileFinder.ScanResults scanResults)

--- a/src/StateSmith.Cli/Run/RunHandler.cs
+++ b/src/StateSmith.Cli/Run/RunHandler.cs
@@ -109,12 +109,12 @@ public class RunHandler
             var path = Path.GetDirectoryName(diagramFile);
             watcher.Path = path!=null && path.Length>0 ? path : "."; 
             watcher.Filter = Path.GetFileName(diagramFile);
-            Console.WriteLine($"Watching {diagramFile}");
-            Console.WriteLine($"Path: {watcher.Path}");
-            Console.WriteLine($"Filter: {watcher.Filter}");
+            _runConsole.WriteLine($"Watching {diagramFile}");
+            _runConsole.WriteLine($"Path: {watcher.Path}");
+            _runConsole.WriteLine($"Filter: {watcher.Filter}");
             watcher.Changed += (sender, e) => 
             {
-                Console.WriteLine($"File {diagramFile} has changed.");
+                _runConsole.WriteLine($"File {diagramFile} has changed.");
                 // TODO only process the changed file
                 RunInnerInner(searchDirectory, scanResults);
             };

--- a/src/StateSmith.Cli/Run/RunHandlerOptions.cs
+++ b/src/StateSmith.Cli/Run/RunHandlerOptions.cs
@@ -15,6 +15,7 @@ public class RunHandlerOptions
     /// </summary>
     public bool DumpErrorsToFile;
     public bool Rebuild;
+    public bool Watch;
 
     public readonly string CurrentDirectory;
 

--- a/src/StateSmith.Cli/Run/RunOptions.cs
+++ b/src/StateSmith.Cli/Run/RunOptions.cs
@@ -42,6 +42,10 @@ public class RunOptions
     [Option("no-csx", HelpText = $"Disables running csx files (useful if {DotnetScriptProgram.Name} is not installed).")]
     public bool NoCsx { get; set; } = false;
 
+    [Option('w', "watch", HelpText = "Watch for changes.")]
+    public bool Watch { get; set; } = false;
+
+
     /// <summary>
     /// https://github.com/StateSmith/StateSmith/issues/348
     /// </summary>

--- a/src/StateSmith.Cli/Run/RunOptions.cs
+++ b/src/StateSmith.Cli/Run/RunOptions.cs
@@ -72,6 +72,7 @@ public class RunOptions
             PropagateExceptions = PropagateExceptions,
             DumpErrorsToFile = DumpErrorsToFile,
             Rebuild = Rebuild,
+            Watch = Watch,
         };
     }
 


### PR DESCRIPTION
Usage: add -w to any run to keep the tool open and watch for changes.
eg. StateSmith.Cli run --lang=JavaScript -hr -w
StateSmith.Cli run --help for more info.

Limitations:
- currently reprocesses every file in the scan if any of the files change. Ideally it would process just the changed file, but that requires refactoring ScanResults in a more invasive way.

Closes #265 