### PR TITLE
Suggestion: simplified run operation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
             "program": "${workspaceFolder}/src/StateSmith.Cli/bin/Debug/net8.0/StateSmith.Cli.dll",
-            "args": [],
+            "args": ["run-lite", "--lang=JavaScript", "--files", "../StateSmithTest/Output/Sim/diagrams/BeadSorter.drawio.svg", "../StateSmithTest/Output/Sim/diagrams/LightSm.drawio.svg"],
             "cwd": "${workspaceFolder}/src/StateSmith.Cli",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "internalConsole",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/StateSmith.Cli/bin/Debug/net8.0/StateSmith.Cli.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/StateSmith.Cli",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build StateSmith.Cli",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/StateSmith.Cli/StateSmith.Cli.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/src/StateSmith.Cli/StateSmith.Cli.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/src/StateSmith.Cli/StateSmith.Cli.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "build StateSmith.Cli",
+            "label": "build",
             "command": "dotnet",
             "type": "process",
             "args": [

--- a/src/StateSmith.Cli/CliArgsParser.cs
+++ b/src/StateSmith.Cli/CliArgsParser.cs
@@ -29,7 +29,7 @@ public class CliArgsParser
             settings.CaseInsensitiveEnumValues = true;
         });
 
-        var parserResult = parser.ParseArguments<RunOptions, CreateOptions, SetupOptions>(args);
+        var parserResult = parser.ParseArguments<RunOptions, RunLiteOptions, CreateOptions, SetupOptions>(args);
         return parserResult;
     }
 

--- a/src/StateSmith.Cli/Program.cs
+++ b/src/StateSmith.Cli/Program.cs
@@ -95,6 +95,12 @@ public class Program
                 var ui = new SetupUi(opts, _console, currentDirectory: _currentDirectory);
                 return ui.Run();
             },
+            (RunLiteOptions opts) =>
+            {
+                PreRunNoArgError(_console);
+                var runLiteUi = new RunLiteUi(opts, _console);
+                return runLiteUi.Run();
+            },
             errs =>
             {
                 if (errs.Count() == 1 && errs.IsVersion())

--- a/src/StateSmith.Cli/Run/DiagramRunner.cs
+++ b/src/StateSmith.Cli/Run/DiagramRunner.cs
@@ -12,12 +12,12 @@ public class DiagramRunner
     //IAnsiConsole _console;
     RunConsole _runConsole;
     DiagramOptions _diagramOptions;
-    RunInfo _runInfo;
+    RunInfo? _runInfo;
     readonly string _searchDirectory;
     private readonly RunHandlerOptions _runHandlerOptions;
     private string CurrentDirectory => _runHandlerOptions.CurrentDirectory;
 
-    public DiagramRunner(RunConsole runConsole, DiagramOptions diagramOptions, RunInfo runInfo, string searchDirectory, RunHandlerOptions runHandlerOptions)
+    public DiagramRunner(RunConsole runConsole, DiagramOptions diagramOptions, RunInfo? runInfo, string searchDirectory, RunHandlerOptions runHandlerOptions)
     {
         _runConsole = runConsole;
         this._diagramOptions = diagramOptions;
@@ -46,7 +46,7 @@ public class DiagramRunner
         string diagramLongerPath = $"{_searchDirectory}/{diagramShortPath}";
         string diagramAbsolutePath = Path.GetFullPath(diagramLongerPath);
 
-        string? csxAbsPath = _runInfo.FindCsxWithDiagram(diagramAbsolutePath);
+        string? csxAbsPath = _runInfo?.FindCsxWithDiagram(diagramAbsolutePath);
         if (csxAbsPath != null)
         {
             var csxRelativePath = Path.GetRelativePath(_searchDirectory, csxAbsPath);

--- a/src/StateSmith.Cli/Run/RunHandler.cs
+++ b/src/StateSmith.Cli/Run/RunHandler.cs
@@ -7,6 +7,7 @@ using StateSmith.Runner;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace StateSmith.Cli.Run;
 
@@ -99,10 +100,9 @@ public class RunHandler
         ReadPastRunInfoDatabase();
         var scanResults = Finder.Scan(searchDirectory: searchDirectory);
 
-        // TODO csxfiles
         // TODO if w flag specified
         var watchers = new List<FileSystemWatcher>();
-        foreach (var diagramFile in scanResults.targetDiagramFiles)
+        foreach (var diagramFile in scanResults.targetDiagramFiles.Union( scanResults.targetCsxFiles ))
         {
             var watcher = new FileSystemWatcher();
             watchers.Add(watcher); // don't let watchers go out of scope yet

--- a/src/StateSmith.Cli/Run/RunHandler.cs
+++ b/src/StateSmith.Cli/Run/RunHandler.cs
@@ -100,31 +100,32 @@ public class RunHandler
         ReadPastRunInfoDatabase();
         var scanResults = Finder.Scan(searchDirectory: searchDirectory);
 
-        // TODO if w flag specified
-        var watchers = new List<FileSystemWatcher>();
-        foreach (var diagramFile in scanResults.targetDiagramFiles.Union( scanResults.targetCsxFiles ))
-        {
-            var watcher = new FileSystemWatcher();
-            watchers.Add(watcher); // don't let watchers go out of scope yet
-            var path = Path.GetDirectoryName(diagramFile);
-            watcher.Path = path!=null && path.Length>0 ? path : "."; 
-            watcher.Filter = Path.GetFileName(diagramFile);
-            _runConsole.WriteLine($"Watching {diagramFile}");
-            _runConsole.WriteLine($"Path: {watcher.Path}");
-            _runConsole.WriteLine($"Filter: {watcher.Filter}");
-            watcher.Changed += (sender, e) => 
-            {
-                _runConsole.WriteLine($"File {diagramFile} has changed.");
-                // TODO only process the changed file. Not sure how to break up ScanResults to do this
-                RunInnerInner(searchDirectory, scanResults);
-            };
-            watcher.EnableRaisingEvents = true;            
-        }
-
         RunInnerInner(searchDirectory, scanResults);
 
-        Console.WriteLine("Watching for changes. Press enter to exit.");
-        Console.ReadLine();
+        if( _runHandlerOptions.Watch) {
+            var watchers = new List<FileSystemWatcher>();
+            foreach (var diagramFile in scanResults.targetDiagramFiles.Union( scanResults.targetCsxFiles ))
+            {
+                var watcher = new FileSystemWatcher();
+                watchers.Add(watcher); // don't let watchers go out of scope yet
+                var path = Path.GetDirectoryName(diagramFile);
+                watcher.Path = path!=null && path.Length>0 ? path : "."; 
+                watcher.Filter = Path.GetFileName(diagramFile);
+                _runConsole.WriteLine($"Watching {diagramFile}");
+                _runConsole.WriteLine($"Path: {watcher.Path}");
+                _runConsole.WriteLine($"Filter: {watcher.Filter}");
+                watcher.Changed += (sender, e) => 
+                {
+                    _runConsole.WriteLine($"File {diagramFile} has changed.");
+                    // TODO only process the changed file. Not sure how to break up ScanResults to do this
+                    RunInnerInner(searchDirectory, scanResults);
+                };
+                watcher.EnableRaisingEvents = true;            
+            }
+
+            Console.WriteLine("Watching for changes. Press enter to exit.");
+            Console.ReadLine();
+        }
     }
 
     private void RunInnerInner(string searchDirectory, SsCsxDiagramFileFinder.ScanResults scanResults) 

--- a/src/StateSmith.Cli/Run/RunHandler.cs
+++ b/src/StateSmith.Cli/Run/RunHandler.cs
@@ -115,7 +115,7 @@ public class RunHandler
             watcher.Changed += (sender, e) => 
             {
                 _runConsole.WriteLine($"File {diagramFile} has changed.");
-                // TODO only process the changed file
+                // TODO only process the changed file. Not sure how to break up ScanResults to do this
                 RunInnerInner(searchDirectory, scanResults);
             };
             watcher.EnableRaisingEvents = true;            

--- a/src/StateSmith.Cli/Run/RunHandler.cs
+++ b/src/StateSmith.Cli/Run/RunHandler.cs
@@ -136,7 +136,6 @@ public class RunHandler
         diagramRunner.Run(scanResults.targetDiagramFiles);
 
         PrintScanInfo(scanResults);
-
     }
 
     private void PrintScanInfo(SsCsxDiagramFileFinder.ScanResults scanResults)

--- a/src/StateSmith.Cli/Run/RunHandler.cs
+++ b/src/StateSmith.Cli/Run/RunHandler.cs
@@ -109,12 +109,12 @@ public class RunHandler
             var path = Path.GetDirectoryName(diagramFile);
             watcher.Path = path!=null && path.Length>0 ? path : "."; 
             watcher.Filter = Path.GetFileName(diagramFile);
-            Console.WriteLine($"Watching {diagramFile}");
-            Console.WriteLine($"Path: {watcher.Path}");
-            Console.WriteLine($"Filter: {watcher.Filter}");
+            _runConsole.WriteLine($"Watching {diagramFile}");
+            _runConsole.WriteLine($"Path: {watcher.Path}");
+            _runConsole.WriteLine($"Filter: {watcher.Filter}");
             watcher.Changed += (sender, e) => 
             {
-                Console.WriteLine($"File {diagramFile} has changed.");
+                _runConsole.WriteLine($"File {diagramFile} has changed.");
                 // TODO only process the changed file
                 RunInnerInner(searchDirectory, scanResults);
             };

--- a/src/StateSmith.Cli/Run/RunHandlerOptions.cs
+++ b/src/StateSmith.Cli/Run/RunHandlerOptions.cs
@@ -15,6 +15,7 @@ public class RunHandlerOptions
     /// </summary>
     public bool DumpErrorsToFile;
     public bool Rebuild;
+    public bool Watch;
 
     public readonly string CurrentDirectory;
 

--- a/src/StateSmith.Cli/Run/RunLiteHandler.cs
+++ b/src/StateSmith.Cli/Run/RunLiteHandler.cs
@@ -1,0 +1,149 @@
+using Spectre.Console;
+using StateSmith.Cli.Utils;
+using StateSmith.Common;
+using StateSmith.Runner;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace StateSmith.Cli.Run;
+
+public class RunLiteHandler
+{
+
+    private CsxOutputParser _parser;
+
+    IAnsiConsole _console;
+    private readonly DiagramOptions _diagramOptions;
+    RunConsole _runConsole;
+    RunLiteOptions _runLiteOptions;
+    private bool IsVerbose => _runLiteOptions.Verbose;
+
+    public RunLiteHandler(IAnsiConsole console, DiagramOptions diagramOptions, RunLiteOptions runLiteOptions)
+    {
+        _console = console;
+        _runLiteOptions = runLiteOptions;
+        this._diagramOptions = diagramOptions;
+
+        _parser = new CsxOutputParser();
+        _runConsole = new RunConsole(_console);
+    }
+
+
+
+    public void Run()
+    {
+        try
+        {
+            RunInner();
+        }
+        catch (Exception ex)
+        {
+            if (ex is not FinishedWithFailureException)
+            {
+                _console.WriteException(ex);
+            }
+
+            Environment.ExitCode = 1;   // TODO - fix. this is not ideal. Might mess up unit tests.
+        }
+    }
+
+    private void RunInner()
+    {
+        RunFiles(_runLiteOptions.Files);
+
+        if( _runLiteOptions.Watch) {
+            var watchers = new List<FileSystemWatcher>();
+            foreach (var diagramFile in _runLiteOptions.Files)
+            {
+                var watcher = new FileSystemWatcher();
+                watchers.Add(watcher); // don't let watchers go out of scope yet
+                var path = Path.GetDirectoryName(diagramFile);
+                watcher.Path = path!=null && path.Length>0 ? path : "."; 
+                watcher.Filter = Path.GetFileName(diagramFile);
+                watcher.Changed += (sender, e) => 
+                {
+                    _runConsole.WriteLine($"File {diagramFile} has changed.");
+                    RunFile(diagramFile);
+                };
+                watcher.EnableRaisingEvents = true;            
+            }
+
+            Console.WriteLine("Watching for changes. Press enter to exit.");
+            Console.ReadLine();
+        }
+    }
+
+    private void RunFiles(IEnumerable<string> files)
+    {
+        foreach (var file in files)
+        {
+            RunFile(file);
+        }
+    }
+
+    private void RunFile(String file) 
+    {
+
+        if(SsCsxFilter.IsScriptFile(file)) {
+            RunCsxFile(file);
+        } else if( DiagramFileAssociator.GetAllDiagramExtensions().Contains(Path.GetExtension(file))) {
+            RunDiagramFile(file);
+        } else {
+            _runConsole.ErrorMarkupLine($"Unknown file type: {file}");
+        }
+    }
+
+    private void RunCsxFile(String file) {
+        AssertDotNetAvailable();
+
+        string csxAbsolutePath = Path.GetFullPath(file);
+
+        _console.WriteLine($"Running script: `{file}`");
+
+        SimpleProcess process = new()
+        {
+            WorkingDirectory = Path.GetDirectoryName(file).ThrowIfNull(),
+            SpecificCommand = DotnetScriptProgram.Name,
+            SpecificArgs = csxAbsolutePath,
+            throwOnExitCode = false
+        };
+        process.EnableEchoToTerminal(_console);
+
+        process.Run(timeoutMs: 60000);
+        if (process.GetExitCode() != 0)
+        {
+            throw new FinishedWithFailureException();
+        }
+    }
+
+    private void RunDiagramFile(string file) {
+        var tmp = new DiagramRunner(
+            _runConsole,
+            _diagramOptions,
+            null,
+            searchDirectory: Path.GetDirectoryName(file).ThrowIfNull(),
+            new RunHandlerOptions(Path.GetDirectoryName(file).ThrowIfNull())
+            {
+                Verbose = IsVerbose,
+                NoCsx = false,
+                Rebuild = false
+            }
+            );
+        tmp.Run((new string[] { file }).ToList() );
+    }
+
+    private void AssertDotNetAvailable() 
+    {
+        (string? versionString, Exception? exception) = DotnetScriptProgram.TryGetVersionString();
+        if (versionString == null)
+        {
+            _runConsole.ErrorMarkupLine($"Did not detect `{DotnetScriptProgram.Name}` program.");
+            _runConsole.WarnMarkupLine($"Not attempting to run StateSmith .csx scripts:");
+
+            // TODO handle better
+            throw new FinishedWithFailureException();
+        }   
+    }
+}

--- a/src/StateSmith.Cli/Run/RunLiteHandler.cs
+++ b/src/StateSmith.Cli/Run/RunLiteHandler.cs
@@ -108,7 +108,7 @@ public class RunLiteHandler
 
         SimpleProcess process = new()
         {
-            WorkingDirectory = Path.GetDirectoryName(file).ThrowIfNull(),
+            WorkingDirectory = ".",
             SpecificCommand = DotnetScriptProgram.Name,
             SpecificArgs = csxAbsolutePath,
             throwOnExitCode = false

--- a/src/StateSmith.Cli/Run/RunLiteHandler.cs
+++ b/src/StateSmith.Cli/Run/RunLiteHandler.cs
@@ -127,7 +127,7 @@ public class RunLiteHandler
             _runConsole,
             _diagramOptions,
             null,
-            searchDirectory: Path.GetDirectoryName(file).ThrowIfNull(),
+            searchDirectory: ".",
             new RunHandlerOptions(Path.GetDirectoryName(file).ThrowIfNull())
             {
                 Verbose = IsVerbose,

--- a/src/StateSmith.Cli/Run/RunLiteHandler.cs
+++ b/src/StateSmith.Cli/Run/RunLiteHandler.cs
@@ -85,7 +85,6 @@ public class RunLiteHandler
 
     private void RunFile(String file) 
     {
-
         foreach( var extension in DiagramFileAssociator.GetAllDiagramExtensions() ) {
             if( file.ToLower().EndsWith(extension.ToLower())) {
                 RunDiagramFile(file);

--- a/src/StateSmith.Cli/Run/RunLiteHandler.cs
+++ b/src/StateSmith.Cli/Run/RunLiteHandler.cs
@@ -14,7 +14,6 @@ public class RunLiteHandler
     private readonly DiagramOptions _diagramOptions;
     RunConsole _runConsole;
     RunLiteOptions _runLiteOptions;
-    private bool IsVerbose => _runLiteOptions.Verbose;
 
     public RunLiteHandler(IAnsiConsole console, DiagramOptions diagramOptions, RunLiteOptions runLiteOptions)
     {
@@ -108,7 +107,7 @@ public class RunLiteHandler
             searchDirectory: ".",
             new RunHandlerOptions(".")
             {
-                Verbose = IsVerbose,
+                Verbose = _runLiteOptions.Verbose,
                 NoCsx = false,
                 Rebuild = false
             }

--- a/src/StateSmith.Cli/Run/RunLiteHandler.cs
+++ b/src/StateSmith.Cli/Run/RunLiteHandler.cs
@@ -29,23 +29,6 @@ public class RunLiteHandler
 
     public void Run()
     {
-        try
-        {
-            RunInner();
-        }
-        catch (Exception ex)
-        {
-            if (ex is not FinishedWithFailureException)
-            {
-                _console.WriteException(ex);
-            }
-
-            Environment.ExitCode = 1;   // TODO - fix. this is not ideal. Might mess up unit tests.
-        }
-    }
-
-    private void RunInner()
-    {
         RunFiles(_runLiteOptions.Files);
 
         if( _runLiteOptions.Watch) {

--- a/src/StateSmith.Cli/Run/RunLiteHandler.cs
+++ b/src/StateSmith.Cli/Run/RunLiteHandler.cs
@@ -128,7 +128,7 @@ public class RunLiteHandler
             _diagramOptions,
             null,
             searchDirectory: ".",
-            new RunHandlerOptions(Path.GetDirectoryName(file).ThrowIfNull())
+            new RunHandlerOptions(".")
             {
                 Verbose = IsVerbose,
                 NoCsx = false,

--- a/src/StateSmith.Cli/Run/RunLiteHandler.cs
+++ b/src/StateSmith.Cli/Run/RunLiteHandler.cs
@@ -86,10 +86,15 @@ public class RunLiteHandler
     private void RunFile(String file) 
     {
 
+        foreach( var extension in DiagramFileAssociator.GetAllDiagramExtensions() ) {
+            if( file.ToLower().EndsWith(extension.ToLower())) {
+                RunDiagramFile(file);
+                return;
+            }
+        }
+
         if(SsCsxFilter.IsScriptFile(file)) {
             RunCsxFile(file);
-        } else if( DiagramFileAssociator.GetAllDiagramExtensions().Contains(Path.GetExtension(file))) {
-            RunDiagramFile(file);
         } else {
             _runConsole.ErrorMarkupLine($"Unknown file type: {file}");
         }

--- a/src/StateSmith.Cli/Run/RunLiteHandler.cs
+++ b/src/StateSmith.Cli/Run/RunLiteHandler.cs
@@ -1,6 +1,5 @@
 using Spectre.Console;
 using StateSmith.Cli.Utils;
-using StateSmith.Common;
 using StateSmith.Runner;
 using System;
 using System.Collections.Generic;
@@ -11,9 +10,6 @@ namespace StateSmith.Cli.Run;
 
 public class RunLiteHandler
 {
-
-    private CsxOutputParser _parser;
-
     IAnsiConsole _console;
     private readonly DiagramOptions _diagramOptions;
     RunConsole _runConsole;
@@ -26,7 +22,6 @@ public class RunLiteHandler
         _runLiteOptions = runLiteOptions;
         this._diagramOptions = diagramOptions;
 
-        _parser = new CsxOutputParser();
         _runConsole = new RunConsole(_console);
     }
 

--- a/src/StateSmith.Cli/Run/RunLiteOptions.cs
+++ b/src/StateSmith.Cli/Run/RunLiteOptions.cs
@@ -1,0 +1,52 @@
+using CommandLine;
+using StateSmith.Cli.Utils;
+using StateSmith.Runner;
+using System.Collections.Generic;
+
+namespace StateSmith.Cli.Run;
+
+// https://github.com/commandlineparser/commandline
+// https://github.com/commandlineparser/commandline/wiki/Mutually-Exclusive-Options
+// TODO find a better name
+[Verb("run-lite", HelpText = Description)]
+public class RunLiteOptions
+{
+    public const string Description = "Run StateSmith code generation.";
+
+    [Option(HelpText = "Specifies programming language for transpiler. Ignored for csx files.")]
+    public TranspilerId Lang { get; set; } = TranspilerId.NotYetSet;
+
+    // TODO remove the need to specify --files, just assume any unprocessed args are files
+    [Option("files", HelpText = "Files to process. Can be .csx or diagram files.")]
+    public IEnumerable<string> Files {get;set;} //sequence
+
+
+    [Option("no-sim-gen", HelpText = "Disables simulation .html file generation. Ignored for csx files.")]
+    public bool NoSimGen { get; set; } = false;
+
+    [Option('w', "watch", HelpText = "Watch for changes. Continue watching for changes after initial run and reprocess any files as they change.")]
+    public bool Watch { get; set; } = false;
+
+    [Option('v', "verbose", HelpText = "Enables verbose info printing.")]
+    public bool Verbose { get; set; } = false;
+
+    // public RunHandlerOptions GetRunHandlerOptions(string currentDirectory)
+    // {
+    //     return new RunHandlerOptions(currentDirectory: currentDirectory)
+    //     {
+    //         Verbose = Verbose,
+    //         NoCsx = NoCsx,
+    //         PropagateExceptions = PropagateExceptions,
+    //         DumpErrorsToFile = DumpErrorsToFile,
+    //         Rebuild = Rebuild,
+    //         Watch = Watch,
+    //     };
+    // }
+
+    public DiagramOptions GetDiagramOptions()
+    {
+        return new DiagramOptions(Lang, NoSimGen);
+    }
+
+}
+

--- a/src/StateSmith.Cli/Run/RunLiteOptions.cs
+++ b/src/StateSmith.Cli/Run/RunLiteOptions.cs
@@ -12,21 +12,21 @@ public class RunLiteOptions
 {
     public const string Description = "Run StateSmith code generation.";
 
-    [Option(HelpText = "Specifies programming language for transpiler. Ignored for csx files.")]
+    [Option(Required=true, HelpText = "Specifies programming language for transpiler. Ignored for csx files.")]
     public TranspilerId Lang { get; set; } = TranspilerId.NotYetSet;
-
-    [Value(0)]
-    public IList<string> Files { get; set; } = new List<string>();
-
-
-    [Option("no-sim-gen", HelpText = "Disables simulation .html file generation. Ignored for csx files.")]
-    public bool NoSimGen { get; set; } = false;
 
     [Option('w', "watch", HelpText = "Watch for changes. Continue watching for changes after initial run and reprocess any files as they change.")]
     public bool Watch { get; set; } = false;
 
     [Option('v', "verbose", HelpText = "Enables verbose info printing.")]
     public bool Verbose { get; set; } = false;
+
+    [Option("no-sim-gen", HelpText = "Disables simulation .html file generation. Ignored for csx files.")]
+    public bool NoSimGen { get; set; } = false;
+
+    [Value(0)]
+    public IList<string> Files { get; set; } = new List<string>();
+
 
     public DiagramOptions GetDiagramOptions()
     {

--- a/src/StateSmith.Cli/Run/RunLiteOptions.cs
+++ b/src/StateSmith.Cli/Run/RunLiteOptions.cs
@@ -1,5 +1,4 @@
 using CommandLine;
-using StateSmith.Cli.Utils;
 using StateSmith.Runner;
 using System.Collections.Generic;
 
@@ -16,9 +15,9 @@ public class RunLiteOptions
     [Option(HelpText = "Specifies programming language for transpiler. Ignored for csx files.")]
     public TranspilerId Lang { get; set; } = TranspilerId.NotYetSet;
 
-    // TODO remove the need to specify --files, just assume any unprocessed args are files
-    [Option("files", HelpText = "Files to process. Can be .csx or diagram files.")]
-    public IEnumerable<string> Files {get;set;} //sequence
+    [Value(0)]
+    public IList<string> Files { get; set; } = new List<string>();
+
 
     [Option("no-sim-gen", HelpText = "Disables simulation .html file generation. Ignored for csx files.")]
     public bool NoSimGen { get; set; } = false;

--- a/src/StateSmith.Cli/Run/RunLiteOptions.cs
+++ b/src/StateSmith.Cli/Run/RunLiteOptions.cs
@@ -20,7 +20,6 @@ public class RunLiteOptions
     [Option("files", HelpText = "Files to process. Can be .csx or diagram files.")]
     public IEnumerable<string> Files {get;set;} //sequence
 
-
     [Option("no-sim-gen", HelpText = "Disables simulation .html file generation. Ignored for csx files.")]
     public bool NoSimGen { get; set; } = false;
 
@@ -29,19 +28,6 @@ public class RunLiteOptions
 
     [Option('v', "verbose", HelpText = "Enables verbose info printing.")]
     public bool Verbose { get; set; } = false;
-
-    // public RunHandlerOptions GetRunHandlerOptions(string currentDirectory)
-    // {
-    //     return new RunHandlerOptions(currentDirectory: currentDirectory)
-    //     {
-    //         Verbose = Verbose,
-    //         NoCsx = NoCsx,
-    //         PropagateExceptions = PropagateExceptions,
-    //         DumpErrorsToFile = DumpErrorsToFile,
-    //         Rebuild = Rebuild,
-    //         Watch = Watch,
-    //     };
-    // }
 
     public DiagramOptions GetDiagramOptions()
     {

--- a/src/StateSmith.Cli/Run/RunLiteUi.cs
+++ b/src/StateSmith.Cli/Run/RunLiteUi.cs
@@ -8,6 +8,14 @@ namespace StateSmith.Cli.Run;
 //   they want to run rather than having the CLI scan for them.
 // - It is stateless. It does not save state to runinfo dbs or manifest files. 
 //   This significantly reduces complexity.
+// 
+// Usage examples:
+//   Transform all specified files (diagrams or csx) in the current directory and subdirectories
+//       zsh> StateSmith.Cli --lang=JavaScript **/*.drawio.svg
+//       bash> StateSmith.Cli --lang=JavaScript **/*.csx  # assumes shopt -s globstar
+//       PowerShell> Get-ChildItem -Path .\*.drawio.svg -Recurse | StateSmith.Cli --lang=JavaScript # TODO verify and avoid foreach
+
+
 public class RunLiteUi
 {
     IAnsiConsole _console;

--- a/src/StateSmith.Cli/Run/RunLiteUi.cs
+++ b/src/StateSmith.Cli/Run/RunLiteUi.cs
@@ -1,0 +1,34 @@
+using Spectre.Console;
+using StateSmith.Cli.Utils;
+
+namespace StateSmith.Cli.Run;
+
+// RunLite is an alternative to RunUi that is more lightweight.
+// - It outsources file and directory scanning to the shell. Users pass in the files
+//   they want to run rather than having the CLI scan for them.
+// - It is stateless. It does not save state to runinfo dbs or manifest files. 
+//   This significantly reduces complexity.
+public class RunLiteUi
+{
+    IAnsiConsole _console;
+    RunLiteOptions opts;
+    RunLiteHandler runLiteHandler;
+
+    public RunLiteUi(RunLiteOptions opts, IAnsiConsole _console)
+    {
+        this.opts = opts;
+        runLiteHandler = new(_console, opts.GetDiagramOptions(), opts);
+        this._console = _console;
+    }
+
+
+    public int Run()
+    {
+        _console.MarkupLine("");
+        UiHelper.AddSectionLeftHeader(_console, "RunLite");
+
+        runLiteHandler.Run();
+        return 0;
+    }
+
+}

--- a/src/StateSmith.Cli/Run/RunLiteUi.cs
+++ b/src/StateSmith.Cli/Run/RunLiteUi.cs
@@ -6,8 +6,9 @@ namespace StateSmith.Cli.Run;
 // RunLite is an alternative to RunUi that is more lightweight.
 // - It outsources file and directory scanning to the shell. Users pass in the files
 //   they want to run rather than having the CLI scan for them.
-// - It is stateless. It does not save state to runinfo dbs or manifest files. 
-//   This significantly reduces complexity.
+// - It is stateless. It does not save state to runinfo dbs or manifest files.
+//   This significantly reduces complexity, but it still provides the ability to
+//   watch for changes and re-run changed files.
 // 
 // Usage examples:
 //   Transform all specified files (diagrams or csx) in the current directory and subdirectories

--- a/src/StateSmith.Cli/Run/RunLiteUi.cs
+++ b/src/StateSmith.Cli/Run/RunLiteUi.cs
@@ -14,7 +14,8 @@ namespace StateSmith.Cli.Run;
 //   Transform all specified files (diagrams or csx) in the current directory and subdirectories
 //       zsh> StateSmith.Cli --lang=JavaScript **/*.drawio.svg
 //       bash> StateSmith.Cli --lang=JavaScript **/*.csx  # assumes shopt -s globstar
-//       PowerShell> Get-ChildItem -Path .\*.drawio.svg -Recurse | StateSmith.Cli --lang=JavaScript # TODO verify and avoid foreach
+//       cmd.exe> StateSmith.Cli --lang=JavaScript *.drawio.svg   # current directory only # TODO verify
+//       PowerShell> Get-ChildItem -Path .\*.drawio.svg -Recurse | ForEach StateSmith.Cli --lang=JavaScript # TODO verify and avoid foreach
 
 
 public class RunLiteUi

--- a/src/StateSmith.Cli/Run/RunOptions.cs
+++ b/src/StateSmith.Cli/Run/RunOptions.cs
@@ -42,7 +42,7 @@ public class RunOptions
     [Option("no-csx", HelpText = $"Disables running csx files (useful if {DotnetScriptProgram.Name} is not installed).")]
     public bool NoCsx { get; set; } = false;
 
-    [Option('w', "watch", HelpText = "Watch for changes.")]
+    [Option('w', "watch", HelpText = "Watch for changes. Continue watching for changes after initial run and reprocess any files as they change.")]
     public bool Watch { get; set; } = false;
 
 

--- a/src/StateSmith.Cli/Run/RunOptions.cs
+++ b/src/StateSmith.Cli/Run/RunOptions.cs
@@ -42,6 +42,10 @@ public class RunOptions
     [Option("no-csx", HelpText = $"Disables running csx files (useful if {DotnetScriptProgram.Name} is not installed).")]
     public bool NoCsx { get; set; } = false;
 
+    [Option('w', "watch", HelpText = "Watch for changes.")]
+    public bool Watch { get; set; } = false;
+
+
     /// <summary>
     /// https://github.com/StateSmith/StateSmith/issues/348
     /// </summary>

--- a/src/StateSmith.Cli/Run/RunOptions.cs
+++ b/src/StateSmith.Cli/Run/RunOptions.cs
@@ -72,6 +72,7 @@ public class RunOptions
             PropagateExceptions = PropagateExceptions,
             DumpErrorsToFile = DumpErrorsToFile,
             Rebuild = Rebuild,
+            Watch = Watch,
         };
     }
 


### PR DESCRIPTION
Here's a proof of concept for a simpler "run" operation that I'm calling run-lite.

```
// RunLite is an alternative to RunUi that is more lightweight.
// - It outsources file and directory scanning to the shell. Users pass in the files
//   they want to run rather than having the CLI scan for them.
// - It is stateless. It does not save state to runinfo dbs or manifest files.
//   This significantly reduces complexity, but it still provides the ability to
//   watch for changes and re-run changed files.
// 
// Usage examples:
//   Transform all specified files (diagrams or csx) in the current directory and subdirectories
//       zsh> StateSmith.Cli --lang=JavaScript **/*.drawio.svg
//       bash> StateSmith.Cli --lang=JavaScript **/*.csx  # assumes shopt -s globstar
//       cmd.exe> StateSmith.Cli --lang=JavaScript *.drawio.svg   # current directory only # TODO verify
//       PowerShell> Get-ChildItem -Path .\*.drawio.svg -Recurse | ForEach StateSmith.Cli --lang=JavaScript # TODO verify and avoid foreach
```


I wanted to get your take on it. For simple transforms like diagram-only and even csx transforms at least, it seems like it maintains most of the power of the regular "run" command but without the complexity.  And because it's less complex, it's easier for users to understand as well. As a user I just need to know I can pass it a list of files and it will process them, and I don't need to know anything about the state that the regular run command maintains in the background.

For more complex directory structures it may make sense to have a more complex run command, but it seems like most users won't need that level of sophistication.

NOTE: this PR also includes unmerged changes from https://github.com/StateSmith/StateSmith/pull/371
