### PR TITLE
Calls base class constructor when generating python code.

### DIFF
--- a/src/StateSmith/Output/Gil/Python/PythonGilVisitor.cs
+++ b/src/StateSmith/Output/Gil/Python/PythonGilVisitor.cs
@@ -265,9 +265,13 @@ public class PythonGilVisitor : CSharpSyntaxWalker
             throw new NotImplementedException("Constructors with parameters are not yet supported.");
         }
 
-        //AddIndent(1);
-        sb.AppendLine("def __init__(self):");
+        sb.AppendLine("def __init__(self, *args, **kwargs):");
         sb.AppendLine(PostProcessor.trimBlankLinesMarker);
+        if (!string.IsNullOrWhiteSpace(renderConfigPython.Extends))
+        {
+            AddIndent(2);
+            sb.Append("super().__init__(*args, **kwargs)");
+        }
 
         // get class fields
         var fields = node.Ancestors().OfType<ClassDeclarationSyntax>().First().ChildNodes().OfType<FieldDeclarationSyntax>();


### PR DESCRIPTION
In Python, if a constructor is declared, it has to explicitly call the base class constructor, otherwise it's never called.
Currently the generated class constructor looks something like this:
```
    # State machine constructor. Must be called before start or dispatch event functions. Not thread safe.
    def __init__(self):
        # Used internally by state machine. Feel free to inspect, but don't modify.
        self.stateId = None
```
This PR modifies the inherited class constructor, so that the base class constructor gets called with any parameter it needs.
 
```
    # State machine constructor. Must be called before start or dispatch event functions. Not thread safe.
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        # Used internally by state machine. Feel free to inspect, but don't modify.
        self.stateId = None
```