### PR TITLE
add “extern C” blocks 

### DIFF
--- a/src/StateSmith/Output/Gil/C99/C99GenVisitor.cs
+++ b/src/StateSmith/Output/Gil/C99/C99GenVisitor.cs
@@ -71,6 +71,10 @@ public class C99GenVisitor : CSharpSyntaxWalker
         sb.AppendLine("#include <stdint.h>");
         sb.AppendLineIfNotBlank(renderConfigC.HFileIncludes);
         sb.AppendLine();
+        sb.AppendLine("#ifdef __cplusplus");
+        sb.AppendLine("extern \"C\" {");
+        sb.AppendLine("#endif");
+        sb.AppendLine();
     }
 
     private void OutputCFileTopSections()

--- a/src/StateSmith/Output/Gil/C99/IncludeGuardProvider.cs
+++ b/src/StateSmith/Output/Gil/C99/IncludeGuardProvider.cs
@@ -40,6 +40,9 @@ public class IncludeGuardProvider
 
     public void OutputIncludeGuardBottom(StringBuilder hFileSb)
     {
+        hFileSb.AppendLine($"#ifdef __cplusplus");
+        hFileSb.AppendLine($"}}");
+        hFileSb.AppendLine($"#endif");
         if (includeGuardLabel != null)
         {
             hFileSb.AppendLine($"#endif // {includeGuardLabel}");


### PR DESCRIPTION
Add extern "C" in header files which auto generated form --lang C99, to make sure C++ programs see the correct linkage