### PR TITLE
Add framework 9.0 support

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Install dependencies
       run: dotnet restore src/StateSmith.sln
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,6 +25,7 @@ jobs:
             6.0.x
             7.0.x
             8.0.x
+            9.0.x
       - name: Install dependencies
         run: dotnet restore src/StateSmith.sln
 

--- a/src/StateSmith.Cli/StateSmith.Cli.csproj
+++ b/src/StateSmith.Cli/StateSmith.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <Version>0.17.4</Version>
     <Company>Adam Fraser-Kruck</Company>
     <Product>StateSmith</Product>


### PR DESCRIPTION
Since many users probably have the 9.0 SDK installed, it's convenient to be able to build and run using the same framework.