### PR TITLE
SimWebGenerator.cs: copy over the name of the statemachine 

### DIFF
--- a/src/StateSmith/Output/Sim/SimWebGenerator.cs
+++ b/src/StateSmith/Output/Sim/SimWebGenerator.cs
@@ -67,6 +67,7 @@ public class SimWebGenerator
         var enablePreDiagramBasedSettings = false;  // need to stop it from trying to read diagram early as fake diagram path is used
         runner = new(diagramPath: "placeholder-updated-in-generate-method.txt", renderConfig: new SimRenderConfig(), transpilerId: TranspilerId.JavaScript, algorithmId: mainRunnerSettings.algorithmId, enablePDBS: enablePreDiagramBasedSettings);
         runner.Settings.propagateExceptions = true;
+        runner.Settings.stateMachineName = mainRunnerSettings.stateMachineName;  // Copy over the state machine name
 
         // Registering DI services must be done before accessing `runner.SmTransformer`.
         simDiServiceProvider = runner.GetExperimentalAccess().DiServiceProvider;


### PR DESCRIPTION
Currently, SimWebGenerator fails when multiple statemachine nodes at root level:
`Exception ArgumentException : State machine name not specified. Expected diagram to have find 1 Statemachine node at root level. Instead, found 2.`

With this fix, the simulation is generated per node as expected.

Also [build instructions](https://github.com/StateSmith/StateSmith/wiki/Building-Source-and-Running-Tests) are somewhat unclear. I have zero experience with dotnet and it took a long time and many prompts to get ss.cli running locally to test my fix against my procjet. Some guidance about dotnet build/publish/pack/tool would have been very nice. Also i could not figure out how to work in csx with `#r "nuget: StateSmith, 0.0.0-local-build"`, i had to use direct dll reference (always got error "'Output' not found in namespace 'StateSmith'). Could not get ss.li to not use `0.0.1000-nugettest`.