### PR TITLE
Fix python tests on mac

### DIFF
--- a/src/StateSmithTest/spec/2/Python/SharedCompilationFixture.cs
+++ b/src/StateSmithTest/spec/2/Python/SharedCompilationFixture.cs
@@ -44,7 +44,7 @@ public class SharedCompilationFixture
         process = new()
         {
             WorkingDirectory = OutputDirectory,
-            ProgramPath = "python",
+            ProgramPath = "python3",
             Args = " -m compileall ."   // https://stackoverflow.com/questions/5607283/how-can-i-manually-generate-a-pyc-file-from-a-py-file
         };
         process.Run(timeoutMs: SimpleProcess.DefaultLongTimeoutMs);

--- a/src/StateSmithTest/spec/2/Python/Spec2TestsPython.cs
+++ b/src/StateSmithTest/spec/2/Python/Spec2TestsPython.cs
@@ -18,7 +18,7 @@ public class Spec2TestsPython : Spec2Tests, IClassFixture<SharedCompilationFixtu
         SimpleProcess process = new()
         {
             WorkingDirectory = SharedCompilationFixture.OutputDirectory,
-            ProgramPath = "python",
+            ProgramPath = "python3",
             Args = $" MainClass.py {testEvents}"
         };
         process.Run(SimpleProcess.DefaultLongTimeoutMs);


### PR DESCRIPTION
Macs require specifying the version of python explicitly. There is not a default "python" binary.
Tests pass on mac and linux. I have not verified win.