### PR TITLE
Fix ci cd typescript issue

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: '22'  # stick to 22 for now. 23 has some bumps causing TypeScript tests to fail: https://github.com/nodejs/node/issues/55417
 
-      - run: npm install -g typescript
+      - run: npm install -g typescript@5.6.3
           
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: '22'  # stick to 22 for now. 23 has some bumps causing TypeScript tests to fail: https://github.com/nodejs/node/issues/55417
 
-      - run: npm install -g typescript@5.6.3
+      - run: npm install -g typescript@5.6.3 # pin to 5.6.3 to be compatible with Node 22
           
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
TypeScript specification tests were failing on CI/CD github actions with error messages like:
```
Error: node_modules/@types/node/buffer.d.ts(645,19): error TS2430: Interface 'Buffer' incorrectly extends interface 'Uint8Array<ArrayBufferLike>'.
[xUnit.net 00:00:08.39]     Spec.Spec2.TypeScript.Spec2TestsTypeScript.Test7_DeepHistory1_HistoryDefaultToChoice [FAIL]
  The types of 'slice(...).buffer' are incompatible between these types.
[xUnit.net 00:00:08.39]     Spec.Spec2.TypeScript.Spec2TestsTypeScript.Test7_History1_OffSelfTranstion_1 [FAIL]
[xUnit.net 00:00:08.39]     Spec.Spec2.TypeScript.Spec2TestsTypeScript.Test4_ParentChildTransitions [FAIL]
    Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
[xUnit.net 00:00:08.39]     Spec.Spec2.TypeScript.Spec2TestsTypeScript.Test6_Variables_AutoVar [FAIL]
      Type 'SharedArrayBuffer' is not assignable to type 'ArrayBuffer'.
[xUnit.net 00:00:08.39]     Spec.Spec2.TypeScript.Spec2TestsTypeScript.Test10_Choice_1 [FAIL]
        Types of property '[Symbol.toStringTag]' are incompatible.
[xUnit.net 00:00:08.39]     Spec.Spec2.TypeScript.Spec2TestsTypeScript.Test7_History1_OffSelfTranstion_2 [FAIL]
          Type '"SharedArrayBuffer"' is not assignable to type '"ArrayBuffer"'.
[xUnit.net 00:00:08.39]     Spec.Spec2.TypeScript.Spec2TestsTypeScript.Test4B_LocalTransitionExample [FAIL]
Error: node_modules/@types/node/fs/promises.d.ts(59,66): error TS2344: Type 'Buffer' does not satisfy the constraint 'ArrayBufferView'.
[xUnit.net 00:00:08.39]     Spec.Spec2.TypeScript.Spec2TestsTypeScript.Test7_DeepHistory2 [FAIL]
  Type 'Buffer' is not assignable to type 'Uint8Array<ArrayBufferLike> | DataView<ArrayBufferLike>'.
[xUnit.net 00:00:08.40]     Spec.Spec2.TypeScript.Spec2TestsTypeScript.Test4D_ExternalTransitionExample [FAIL]
    Type 'Buffer' is not assignable to type 'Uint8Array<ArrayBufferLike>'.
[xUnit.net 00:00:08.40]     Spec.Spec2.TypeScript.Spec2TestsTypeScript.Test10_Choice_2 [FAIL]
      The types of 'slice(...).buffer' are incompatible between these types.
[xUnit.net 00:00:08.40]     Spec.Spec2.TypeScript.Spec2TestsTypeScript.Test7_Choice_2 [FAIL]
        Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
[xUnit.net 00:00:08.41]     Spec.Spec2.TypeScript.Spec2TestsTypeScript.Test6_MetaExpansions [FAIL]
          Type 'SharedArrayBuffer' is not assignable to type 'ArrayBuffer'.
[xUnit.net 00:00:08.41]     Spec.Spec2.TypeScript.Spec2TestsTypeScript.Test10_Choice_0 [FAIL]
            Types of property '[Symbol.toStringTag]' are incompatible.
[xUnit.net 00:00:08.41]     Spec.Spec2.TypeScript.Spec2TestsTypeScript.Test9_Choice_3_2 [FAIL]
              Type '"SharedArrayBuffer"' is not assignable to type '"ArrayBuffer"'.
[xUnit.net 00:00:08.41]     Spec.Spec2.TypeScript.Spec2TestsTypeScript.Test8_Choice_2 [FAIL]
Error: node_modules/@types/node/fs/promises.d.ts(241,49): error TS2344: Type 'Buffer' does not satisfy the constraint 'ArrayBufferView'.
```

See https://github.com/StateSmith/StateSmith/actions/runs/16794023061/job/47561104089#step:8:645

Specifying typescript version to be compatible with Node 22 seems to have fixed it.